### PR TITLE
Feat: add failed state in workflow

### DIFF
--- a/api/v1alpha1/event.go
+++ b/api/v1alpha1/event.go
@@ -28,6 +28,8 @@ const (
 	MessageSuccessfully = "WorkflowRun finished successfully"
 	// MessageTerminated is the message for terminated
 	MessageTerminated = "WorkflowRun finished with termination"
+	// MessageFailed is the message for failed
+	MessageFailed = "WorkflowRun finished with failure"
 	// MessageFailedGenerate is the message for failed to generate
 	MessageFailedGenerate = "fail to generate workflow runners"
 	// MessageFailedExecute is the message for failed to execute

--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -102,6 +102,8 @@ const (
 	WorkflowStateSuspending WorkflowRunPhase = "suspending"
 	// WorkflowStateTerminated means the workflow run is terminated
 	WorkflowStateTerminated WorkflowRunPhase = "terminated"
+	// WorkflowStateFailed means the workflow run is failed
+	WorkflowStateFailed WorkflowRunPhase = "failed"
 	// WorkflowStateSucceeded means the workflow run is succeeded
 	WorkflowStateSucceeded WorkflowRunPhase = "succeeded"
 	// WorkflowStateSkipped means the workflow run is skipped

--- a/controllers/workflowrun_controller.go
+++ b/controllers/workflowrun_controller.go
@@ -136,6 +136,11 @@ func (r *WorkflowRunReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			return ctrl.Result{RequeueAfter: duration}, r.patchStatus(logCtx, run, isUpdate)
 		}
 		return ctrl.Result{}, r.patchStatus(logCtx, run, isUpdate)
+	case v1alpha1.WorkflowStateFailed:
+		logCtx.Info("Workflow return state=Failed")
+		r.doWorkflowFinish(run)
+		r.Recorder.Event(run, event.Normal(v1alpha1.ReasonExecute, v1alpha1.MessageFailed))
+		return ctrl.Result{}, r.patchStatus(logCtx, run, isUpdate)
 	case v1alpha1.WorkflowStateTerminated:
 		logCtx.Info("Workflow return state=Terminated")
 		r.doWorkflowFinish(run)

--- a/pkg/executor/workflow.go
+++ b/pkg/executor/workflow.go
@@ -107,7 +107,10 @@ func (w *workflowExecutor) ExecuteRunners(ctx monitorContext.Context, taskRunner
 		StepStatusCache.Delete(cacheKey)
 	}
 	if checkWorkflowTerminated(status, allTasksDone) {
-		return v1alpha1.WorkflowStateTerminated, nil
+		if isTerminatedManually(status) {
+			return v1alpha1.WorkflowStateTerminated, nil
+		}
+		return v1alpha1.WorkflowStateFailed, nil
 	}
 	if checkWorkflowSuspended(status) {
 		return v1alpha1.WorkflowStateSuspending, nil
@@ -146,7 +149,10 @@ func (w *workflowExecutor) ExecuteRunners(ctx monitorContext.Context, taskRunner
 		e.cleanBackoffTimesForTerminated()
 		if checkWorkflowTerminated(status, allTasksDone) {
 			wfContext.CleanupMemoryStore(e.instance.Name, e.instance.Namespace)
-			return v1alpha1.WorkflowStateTerminated, nil
+			if isTerminatedManually(status) {
+				return v1alpha1.WorkflowStateTerminated, nil
+			}
+			return v1alpha1.WorkflowStateFailed, nil
 		}
 	}
 	if status.Suspend {
@@ -157,6 +163,20 @@ func (w *workflowExecutor) ExecuteRunners(ctx monitorContext.Context, taskRunner
 		return v1alpha1.WorkflowStateSucceeded, nil
 	}
 	return v1alpha1.WorkflowStateExecuting, nil
+}
+
+func isTerminatedManually(status *v1alpha1.WorkflowRunStatus) bool {
+	manually := false
+	for _, step := range status.Steps {
+		if step.Phase == v1alpha1.WorkflowStepPhaseFailed {
+			if step.Reason == types.StatusReasonTerminate {
+				manually = true
+			} else {
+				return false
+			}
+		}
+	}
+	return manually
 }
 
 func checkWorkflowTerminated(status *v1alpha1.WorkflowRunStatus, allTasksDone bool) bool {

--- a/pkg/executor/workflow_test.go
+++ b/pkg/executor/workflow_test.go
@@ -277,7 +277,7 @@ var _ = Describe("Test Workflow", func() {
 		time.Sleep(1 * time.Second)
 		state, err = wf.ExecuteRunners(ctx, runners)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(state).Should(BeEquivalentTo(v1alpha1.WorkflowStateTerminated))
+		Expect(state).Should(BeEquivalentTo(v1alpha1.WorkflowStateFailed))
 		workflowStatus := instance.Status
 		Expect(workflowStatus.ContextBackend.Name).Should(BeEquivalentTo("workflow-" + instance.Name + "-context"))
 		workflowStatus.ContextBackend = nil
@@ -363,7 +363,7 @@ var _ = Describe("Test Workflow", func() {
 		time.Sleep(1 * time.Second)
 		state, err = wf.ExecuteRunners(ctx, runners)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(state).Should(BeEquivalentTo(v1alpha1.WorkflowStateTerminated))
+		Expect(state).Should(BeEquivalentTo(v1alpha1.WorkflowStateFailed))
 		workflowStatus := instance.Status
 		Expect(workflowStatus.ContextBackend.Name).Should(BeEquivalentTo("workflow-" + instance.Name + "-context"))
 		workflowStatus.ContextBackend = nil
@@ -456,7 +456,7 @@ var _ = Describe("Test Workflow", func() {
 		time.Sleep(1 * time.Second)
 		state, err = wf.ExecuteRunners(ctx, runners)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(state).Should(BeEquivalentTo(v1alpha1.WorkflowStateTerminated))
+		Expect(state).Should(BeEquivalentTo(v1alpha1.WorkflowStateFailed))
 		workflowStatus := instance.Status
 		Expect(workflowStatus.ContextBackend.Name).Should(BeEquivalentTo("workflow-" + instance.Name + "-context"))
 		workflowStatus.ContextBackend = nil
@@ -548,7 +548,7 @@ var _ = Describe("Test Workflow", func() {
 		time.Sleep(1 * time.Second)
 		state, err = wf.ExecuteRunners(ctx, runners)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(state).Should(BeEquivalentTo(v1alpha1.WorkflowStateTerminated))
+		Expect(state).Should(BeEquivalentTo(v1alpha1.WorkflowStateFailed))
 		workflowStatus = instance.Status
 		Expect(workflowStatus.ContextBackend.Name).Should(BeEquivalentTo("workflow-" + instance.Name + "-context"))
 		workflowStatus.ContextBackend = nil
@@ -634,7 +634,7 @@ var _ = Describe("Test Workflow", func() {
 		ctx := monitorContext.NewTraceContext(context.Background(), "test-app")
 		state, err := wf.ExecuteRunners(ctx, runners)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(state).Should(BeEquivalentTo(v1alpha1.WorkflowStateTerminated))
+		Expect(state).Should(BeEquivalentTo(v1alpha1.WorkflowStateFailed))
 		instance.Status.ContextBackend = nil
 		cleanStepTimeStamp(&instance.Status)
 		Expect(cmp.Diff(instance.Status, v1alpha1.WorkflowRunStatus{
@@ -705,6 +705,10 @@ var _ = Describe("Test Workflow", func() {
 						Name: "s2-sub2",
 						Type: "failed-after-retries",
 					},
+					{
+						Name: "s2-sub3",
+						Type: "terminate",
+					},
 				},
 			},
 			{
@@ -718,7 +722,7 @@ var _ = Describe("Test Workflow", func() {
 		ctx := monitorContext.NewTraceContext(context.Background(), "test-app")
 		state, err := wf.ExecuteRunners(ctx, runners)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(state).Should(BeEquivalentTo(v1alpha1.WorkflowStateTerminated))
+		Expect(state).Should(BeEquivalentTo(v1alpha1.WorkflowStateFailed))
 		instance.Status.ContextBackend = nil
 		cleanStepTimeStamp(&instance.Status)
 		Expect(cmp.Diff(instance.Status, v1alpha1.WorkflowRunStatus{
@@ -749,6 +753,11 @@ var _ = Describe("Test Workflow", func() {
 						Type:   "failed-after-retries",
 						Phase:  v1alpha1.WorkflowStepPhaseFailed,
 						Reason: types.StatusReasonFailedAfterRetries,
+					}, {
+						Name:   "s2-sub3",
+						Type:   "terminate",
+						Phase:  v1alpha1.WorkflowStepPhaseFailed,
+						Reason: types.StatusReasonTerminate,
 					},
 				},
 			}, {
@@ -1040,7 +1049,7 @@ var _ = Describe("Test Workflow", func() {
 		wf := New(instance, k8sClient)
 		state, err := wf.ExecuteRunners(ctx, runners)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(state).Should(BeEquivalentTo(v1alpha1.WorkflowStateTerminated))
+		Expect(state).Should(BeEquivalentTo(v1alpha1.WorkflowStateFailed))
 		workflowStatus := instance.Status
 		Expect(workflowStatus.ContextBackend.Name).Should(BeEquivalentTo("workflow-" + instance.Name + "-context"))
 		workflowStatus.ContextBackend = nil
@@ -1137,7 +1146,7 @@ var _ = Describe("Test Workflow", func() {
 		wf = New(instance, k8sClient)
 		state, err = wf.ExecuteRunners(ctx, runners)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(state).Should(BeEquivalentTo(v1alpha1.WorkflowStateTerminated))
+		Expect(state).Should(BeEquivalentTo(v1alpha1.WorkflowStateFailed))
 		workflowStatus = instance.Status
 		Expect(workflowStatus.ContextBackend.Name).Should(BeEquivalentTo("workflow-" + instance.Name + "-context"))
 		workflowStatus.ContextBackend = nil
@@ -1409,7 +1418,7 @@ var _ = Describe("Test Workflow", func() {
 		ctx := monitorContext.NewTraceContext(context.Background(), "test-app")
 		state, err := wf.ExecuteRunners(ctx, runners)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(state).Should(BeEquivalentTo(v1alpha1.WorkflowStateTerminated))
+		Expect(state).Should(BeEquivalentTo(v1alpha1.WorkflowStateFailed))
 		instance.Status.ContextBackend = nil
 		cleanStepTimeStamp(&instance.Status)
 		Expect(cmp.Diff(instance.Status, v1alpha1.WorkflowRunStatus{
@@ -1923,9 +1932,10 @@ var _ = Describe("Test Workflow", func() {
 				},
 			}, {
 				StepStatus: v1alpha1.StepStatus{
-					Name:  "s2",
-					Type:  "terminate",
-					Phase: v1alpha1.WorkflowStepPhaseSucceeded,
+					Name:   "s2",
+					Type:   "terminate",
+					Phase:  v1alpha1.WorkflowStepPhaseFailed,
+					Reason: types.StatusReasonTerminate,
 				},
 			}},
 		})).Should(BeEquivalentTo(""))
@@ -1981,9 +1991,10 @@ var _ = Describe("Test Workflow", func() {
 				},
 			}, {
 				StepStatus: v1alpha1.StepStatus{
-					Name:  "s2",
-					Type:  "step-group",
-					Phase: v1alpha1.WorkflowStepPhaseSucceeded,
+					Name:   "s2",
+					Type:   "step-group",
+					Phase:  v1alpha1.WorkflowStepPhaseFailed,
+					Reason: types.StatusReasonTerminate,
 				},
 				SubStepsStatus: []v1alpha1.StepStatus{
 					{
@@ -1991,9 +2002,10 @@ var _ = Describe("Test Workflow", func() {
 						Type:  "success",
 						Phase: v1alpha1.WorkflowStepPhaseSucceeded,
 					}, {
-						Name:  "s2-sub2",
-						Type:  "terminate",
-						Phase: v1alpha1.WorkflowStepPhaseSucceeded,
+						Name:   "s2-sub2",
+						Type:   "terminate",
+						Phase:  v1alpha1.WorkflowStepPhaseFailed,
+						Reason: types.StatusReasonTerminate,
 					},
 				},
 			}},
@@ -2229,9 +2241,10 @@ func makeRunner(step v1alpha1.WorkflowStep, subTaskRunners []types.TaskRunner) t
 	case "terminate":
 		run = func(ctx wfContext.Context, options *types.TaskRunOptions) (v1alpha1.StepStatus, *types.Operation, error) {
 			return v1alpha1.StepStatus{
-					Name:  step.Name,
-					Type:  "terminate",
-					Phase: v1alpha1.WorkflowStepPhaseSucceeded,
+					Name:   step.Name,
+					Type:   "terminate",
+					Phase:  v1alpha1.WorkflowStepPhaseFailed,
+					Reason: types.StatusReasonTerminate,
 				}, &types.Operation{
 					Terminated: true,
 				}, nil


### PR DESCRIPTION
Signed-off-by: FogDong <dongtianxin.tx@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

 Add failed state in workflow to separate failed and terminated

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->