### PR TITLE
Fix: input error stores structure type data

### DIFF
--- a/pkg/tasks/custom/task.go
+++ b/pkg/tasks/custom/task.go
@@ -364,7 +364,7 @@ func getInputsTemplate(ctx wfContext.Context, step v1alpha1.WorkflowStep, basicV
 		if err != nil {
 			continue
 		}
-		inputsTempl += fmt.Sprintf("\ninputs: \"%s\": %s", input.From, s)
+		inputsTempl += fmt.Sprintf("\ninputs: \"%s\": {\n%s\n}", input.From, s)
 	}
 	return inputsTempl
 }

--- a/pkg/tasks/custom/task_test.go
+++ b/pkg/tasks/custom/task_test.go
@@ -701,6 +701,20 @@ func TestValidateIfValue(t *testing.T) {
 			expected:    false,
 		},
 		{
+			name: "input value is struct",
+			step: v1alpha1.WorkflowStep{
+				WorkflowStepBase: v1alpha1.WorkflowStepBase{
+					If: `inputs["test-struct"].hello == "world"`,
+					Inputs: v1alpha1.StepInputs{
+						{
+							From: "test-struct",
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
 			name: "dash in if",
 			step: v1alpha1.WorkflowStep{
 				WorkflowStepBase: v1alpha1.WorkflowStepBase{
@@ -782,6 +796,9 @@ func newWorkflowContextForTest(t *testing.T) wfContext.Context {
 	v, err = value.NewValue(`"yes"`, nil, "")
 	r.NoError(err)
 	r.NoError(wfCtx.SetVar(v, "test"))
+	v, err = value.NewValue(`{hello: "world"}`, nil, "")
+	r.NoError(err)
+	r.NoError(wfCtx.SetVar(v, "test-struct"))
 	return wfCtx
 }
 


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
In the following example, if `response.data` is a struct that contains multiple fields, the if statement will parse incorrectly.
this PR fix this bug.

```
response: data: {
 success: true
 code: 200
}
```

```
- name: test-step
  subSteps:
  - name: test-subStep-1
    outputs:
    - name: subStep-1-result
      valueFrom: response.data
    type: webhook
  # cue parse error 
  - if:  inputs["subStep-1-result"].success == true
    inputs:
    - from: subStep-1-result
    name: test-subStep-2
    type: webhook
```

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->