### PR TITLE
Feat: replace deprecated command with environment file

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -14,11 +14,11 @@ jobs:
         id: vars
         run: |
           if [[ ${GITHUB_REF} == "refs/heads/main" ]]; then
-            echo ::set-output name=TAG::latest
+            echo "TAG=latest" >> $GITHUB_OUTPUT
           else
-            echo ::set-output name=TAG::${GITHUB_REF#refs/tags/}
+            echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
           fi
-          echo ::set-output name=GITVERSION::git-$(git rev-parse --short HEAD)
+          echo "GITVERSION=git-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Login ghcr.io
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
         with:
@@ -62,7 +62,7 @@ jobs:
       - name: Get the vars
         id: vars
         run: |
-          echo ::set-output name=TAG::${GITHUB_REF#refs/tags/}
+          echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
       - name: Install Helm
         uses: azure/setup-helm@v1
         with:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -45,9 +45,9 @@ jobs:
         run: |
           if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
             echo "pushing tag: ${{ github.ref_name }}"
-            echo "::set-output name=matrix::${{ env.K3D_IMAGE_VERSIONS }}"
+            echo "matrix=${{ env.K3D_IMAGE_VERSIONS }}" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=matrix::${{ env.K3D_IMAGE_VERSION }}"
+            echo "matrix=${{ env.K3D_IMAGE_VERSION }}" >> $GITHUB_OUTPUT
           fi
 
   e2e-tests:


### PR DESCRIPTION
### Description of your changes

Closes #180 

Update workflows to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
echo ::set-output name=TAG::latest
```

**TO-BE**

```yaml
echo "TAG=latest" >> $GITHUB_OUTPUT
```

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

None

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

None
<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->