### PR TITLE
Fix: Fix output

### DIFF
--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -51,7 +51,7 @@ jobs:
           submodules: true
 
       - name: Cache Go Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .work/pkg
           key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/kubevela/pkg/cue/util"
 	"github.com/kubevela/pkg/util/rand"
 	"github.com/kubevela/pkg/util/singleton"
 	"github.com/kubevela/workflow/pkg/cue/model/sets"
@@ -160,7 +159,7 @@ func (wf *WorkflowContext) Commit(ctx context.Context) error {
 }
 
 func (wf *WorkflowContext) writeToStore() error {
-	varStr, err := util.ToString(wf.vars)
+	varStr, err := sets.ToString(wf.vars)
 	if err != nil {
 		return err
 	}

--- a/pkg/hooks/data_passing.go
+++ b/pkg/hooks/data_passing.go
@@ -71,6 +71,13 @@ func Output(ctx wfContext.Context, taskValue cue.Value, step v1alpha1.WorkflowSt
 				} else {
 					v, err = value.LookupValueByScript(taskValue, fmt.Sprintf("%s.$returns", output.ValueFrom))
 				}
+			} else if v.Err() != nil && !strings.Contains(output.ValueFrom, "$returns.") {
+				parts := strings.Split(output.ValueFrom, "output.")
+				if len(parts) > 1 {
+					v, err = value.LookupValueByScript(taskValue, fmt.Sprintf("%soutput.$returns.%s", parts[0], strings.Join(parts[1:], ".")))
+				} else {
+					v, err = value.LookupValueByScript(taskValue, fmt.Sprintf("%s.$returns", output.ValueFrom))
+				}
 			}
 			// if the error is not nil and the step is not skipped, return the error
 			if err != nil && status.Phase != v1alpha1.WorkflowStepPhaseSkipped {

--- a/pkg/hooks/data_passing.go
+++ b/pkg/hooks/data_passing.go
@@ -64,17 +64,15 @@ func Output(ctx wfContext.Context, taskValue cue.Value, step v1alpha1.WorkflowSt
 		SetAdditionalNameInStatus(stepStatus, step.Name, step.Properties, status)
 		for _, output := range step.Outputs {
 			v, err := value.LookupValueByScript(taskValue, output.ValueFrom)
-			if err != nil && strings.Contains(err.Error(), "not exist") && !strings.Contains(output.ValueFrom, "$returns.") {
-				parts := strings.Split(output.ValueFrom, ".")
-				if len(parts) > 1 {
-					v, err = value.LookupValueByScript(taskValue, fmt.Sprintf("%s.$returns.%s", parts[0], strings.Join(parts[1:], ".")))
-				} else {
-					v, err = value.LookupValueByScript(taskValue, fmt.Sprintf("%s.$returns", output.ValueFrom))
-				}
-			} else if v.Err() != nil && !strings.Contains(output.ValueFrom, "$returns.") {
+			if (err != nil && strings.Contains(err.Error(), "not exist") || v.Err() != nil) && !strings.Contains(output.ValueFrom, "$returns.") {
 				parts := strings.Split(output.ValueFrom, "output.")
 				if len(parts) > 1 {
-					v, err = value.LookupValueByScript(taskValue, fmt.Sprintf("%soutput.$returns.%s", parts[0], strings.Join(parts[1:], ".")))
+					if parts[0] == "" {
+						v, err = value.LookupValueByScript(taskValue, fmt.Sprintf("output.$returns.%s", strings.Join(parts[1:], ".")))
+					} else {
+						v, err = value.LookupValueByScript(taskValue, fmt.Sprintf("%soutput.$returns.%s", parts[0], strings.Join(parts[1:], ".")))
+					}
+
 				} else {
 					v, err = value.LookupValueByScript(taskValue, fmt.Sprintf("%s.$returns", output.ValueFrom))
 				}

--- a/pkg/hooks/data_passing_test.go
+++ b/pkg/hooks/data_passing_test.go
@@ -138,7 +138,6 @@ func TestOutput(t *testing.T) {
 	r.Equal(int(resultInt), 99)
 	r.Equal(stepStatus["mystep"].Phase, v1alpha1.WorkflowStepPhaseSucceeded)
 
-
 	taskValue = cuectx.CompileString(`output: $returns: score: 99`)
 	stepStatus = make(map[string]v1alpha1.StepStatus)
 	err = Output(wfCtx, taskValue, v1alpha1.WorkflowStep{


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes [#6734](https://github.com/kubevela/kubevela/issues/6734)
We looked at the issue and debugged the code. We added following fixes to fix the issue:
1. Add backward compatibility for workflow outputs with builtin function.
2. We observed extra quotes coming in the string written to configmap. Replaced util.ToString to sets.ToString in writeToStore function.
I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
We tested the code by applying KubeVela application and verified the output is proper.
```
apiVersion: core.oam.dev/v1beta1
kind: Application
metadata:
  name: test-app
spec:
  components: []
  workflow:
    steps:
      - name: read-secret
        type: read-object
        properties:
          apiVersion: v1
          kind: Secret
          name: mysecret
        outputs:
          - name: mypasswor1
            valueFrom: |-
              import "encoding/base64"
              "\(base64.Decode(null,output.value.data["password"] ))"
```

Data in ConfigMap:

```
apiVersion: v1
data:
  vars: |
    mypasswor1: "mypassword"
kind: ConfigMap
```
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->