### PR TITLE
Fix: updates the error check on custom tasks to fail on errors 

### DIFF
--- a/pkg/tasks/custom/task.go
+++ b/pkg/tasks/custom/task.go
@@ -192,7 +192,7 @@ func (t *TaskLoader) makeTaskGenerator(templ string) (types.TaskGenerator, error
 				}
 				for _, hook := range options.PostStopHooks {
 					if err := hook(wfCtx, taskv, wfStep, exec.status(), options.StepStatus); err != nil {
-						exec.wfStatus.Message = err.Error()
+						exec.err(wfCtx, false, errors.Wrapf(err, "post-stop hook failed for step '%s': %v", wfStep.Name, err), types.StatusReasonOutput)
 						stepStatus = exec.status()
 						operations = exec.operation()
 						return


### PR DESCRIPTION
fix: updates the error check on custom tasks to fail on errors for workflow run


### Description of your changes

This PR fixes the workflow phase showing succeded even if the workflow fails. 

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Tested the changes locally