### PR TITLE
Fix: Updates the addon-operation WFS to newer image and corrects wait…

### DIFF
--- a/charts/vela-workflow/templates/definitions/addon-operation.yaml
+++ b/charts/vela-workflow/templates/definitions/addon-operation.yaml
@@ -15,79 +15,86 @@ spec:
     cue:
       template: |
         import (
-        	"vela/op"
+                "vela/op"
         )
 
         job: op.#Apply & {
-        	value: {
-        		apiVersion: "batch/v1"
-        		kind:       "Job"
-        		metadata: {
-        			name:      context.name + "-" + context.stepSessionID
-        			namespace: "vela-system"
-        			labels: "enable-addon.oam.dev":          context.name
-        			annotations: "workflow.oam.dev/step": context.stepName
-        		}
-        		spec: {
-        			backoffLimit: 3
-        			template: {
-        				metadata: {
-        					labels: {
-        						"workflow.oam.dev/name":    context.name
-        						"workflow.oam.dev/session": context.stepSessionID
-        					}
-        					annotations: "workflow.oam.dev/step": context.stepName
-        				}
-        				spec: {
-        					containers: [
-        						{
-        							name:  parameter.addonName + "-enable-job"
-        							image: parameter.image
+                value: {
+                        apiVersion: "batch/v1"
+                        kind:       "Job"
+                        metadata: {
+                                name:      context.name + "-" + context.stepSessionID
+                                namespace: "vela-system"
+                                labels: {
+                                        "enable-addon.oam.dev":     context.name
+                                        "workflow.oam.dev/name":    context.name
+                                        "workflow.oam.dev/session": context.stepSessionID
+                                }
+                                annotations: "workflowrun.oam.dev/step": context.stepName
+                        }
+                        spec: {
+                                backoffLimit: 3
+                                template: {
+                                        metadata: {
+                                                labels: {
+                                                        "workflow.oam.dev/name":    context.name
+                                                        "workflow.oam.dev/session": context.stepSessionID
+                                                }
+                                                annotations: "workflow.oam.dev/step": context.stepName
+                                        }
+                                        spec: {
+                                                containers: [
+                                                        {
+                                                                name:  parameter.addonName + "-enable-job"
+                                                                image: parameter.image
 
-        							if parameter.args == _|_ {
-        								command: ["vela", "addon", parameter.operation, parameter.addonName]
-        							}
+                                                                if parameter.args == _|_ {
+                                                                        args: ["addon", parameter.operation, parameter.addonName]
+                                                                }
 
-        							if parameter.args != _|_ {
-        								command: ["vela", "addon", parameter.operation, parameter.addonName] + parameter.args
-        							}
-        						},
-        					]
-        					restartPolicy:  "Never"
-        					serviceAccount: parameter.serviceAccountName
-        				}
-        			}
-        		}
-        	}
+                                                                if parameter.args != _|_ {
+                                                                        args: ["addon", parameter.operation, parameter.addonName] + parameter.args
+                                                                }
+                                                        },
+                                                ]
+                                                restartPolicy:  "Never"
+                                                serviceAccount: parameter.serviceAccountName
+                                        }
+                                }
+                        }
+                }
         }
+
         log: op.#Log & {
-        	source: resources: [{labelSelector: {
-        		"workflow.oam.dev/name":    context.name
-        		"workflow.oam.dev/session": context.stepSessionID
-        	}}]
-        }
-        fail: op.#Steps & {
-        	if job.value.status.failed != _|_ {
-        		if job.value.status.failed > 2 {
-        			breakWorkflow: op.#Fail & {
-        				message: "enable addon failed"
-        			}
-        		}
-        	}
-        }
-        wait: op.#ConditionalWait & {
-        	continue: job.value.status.succeeded != _|_ && job.value.status.succeeded > 0
-        }
-        parameter: {
-        	// +usage=Specify the name of the addon.
-        	addonName: string
-        	// +usage=Specify addon enable args.
-        	args?: [...string]
-        	// +usage=Specify the image
-        	image: *"oamdev/vela-cli:v1.6.4" | string
-        	// +usage=operation for the addon
-        	operation: *"enable" | "upgrade" | "disable"
-        	// +usage=specify serviceAccountName want to use
-        	serviceAccountName: *"kubevela-vela-core" | string
+                source: resources: [{labelSelector: {
+                        "workflow.oam.dev/name":    context.name
+                        "workflow.oam.dev/session": context.stepSessionID
+                }}]
         }
 
+        wait: op.#ConditionalWait & {
+                continue: job.value.status.succeeded != _|_ || job.value.status.failed != _|_
+        }
+
+        fail: op.#Steps & {
+                if job.value.status.failed != _|_ {
+                        if job.value.status.failed > 2 {
+                                breakWorkflow: op.#Fail & {
+                                        message: "enable addon failed"
+                                }
+                        }
+                }
+        }
+
+        parameter: {
+                // +usage=Specify the name of the addon.
+                addonName: string
+                // +usage=Specify addon enable args.
+                args?: [...string]
+                // +usage=Specify the image
+                image: *"oamdev/vela-cli:v1.10.3" | string
+                // +usage=operation for the addon
+                operation: *"enable" | "upgrade" | "disable"
+                // +usage=specify serviceAccountName want to use
+                serviceAccountName: *"kubevela-vela-core" | string
+        }


### PR DESCRIPTION
… logic


### Description of your changes

1. Fixes issues with addon-operation not waiting for correct status reporting of the created Job (always showing as failed despite the addon succeeding).
2. Updates the image in use (latest version) as step fails with the current image. 

Fixes #

1. https://github.com/kubevela/workflow/issues/207
2. https://github.com/kubevela/workflow/issues/208

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [] ~~[Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. ~~
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] ~~Added `backport release-x.y` labels to auto-backport this PR if necessary.~~

### How has this code been tested

- Reproduced issues locally with existing workflow step.
- Deployed updated workstep step.
- Confirmed addons are now created as expected and the WorkflowRun & Step correctly reflect the successful installation of the addon. 


### Special notes for your reviewer
N/A
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the addon-operation workflow step to use the latest image and fixed the wait logic so job status is reported correctly.

- **Bug Fixes**
  - Fixed issue where the step always showed as failed even when the addon succeeded.
  - Improved wait logic to check both succeeded and failed job statuses.

- **Dependencies**
  - Updated the default image to oamdev/vela-cli:v1.10.3.

<!-- End of auto-generated description by cubic. -->

