### PR TITLE
Chore: Updating pkg to v1.10.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/kubevela/kube-trigger v0.1.1-0.20250711201929-51c837aa9bd2
-	github.com/kubevela/pkg v1.9.3-0.20251015050342-14cd204ff6fc
+	github.com/kubevela/pkg v1.10.0
 	github.com/onsi/ginkgo/v2 v2.23.3
 	github.com/onsi/gomega v1.36.2
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -321,6 +321,8 @@ github.com/kubevela/kube-trigger v0.1.1-0.20250711201929-51c837aa9bd2 h1:3FvzYw6
 github.com/kubevela/kube-trigger v0.1.1-0.20250711201929-51c837aa9bd2/go.mod h1:lGeLpXHVxYPulYtVgGatFHFolkmzSmrdyhIQ7BHHJHs=
 github.com/kubevela/pkg v1.9.3-0.20251015050342-14cd204ff6fc h1:nuXTUQRQDJORMopbRD1fV4iwKT43MWgvMERM9YnrSPk=
 github.com/kubevela/pkg v1.9.3-0.20251015050342-14cd204ff6fc/go.mod h1:EmM4VIyU7KxDmPBq9hG4GpSZbGwiM76/W/8paLBk8wY=
+github.com/kubevela/pkg v1.10.0 h1:opwBitEK+Un1StWhz+iq+bWjZDge+Va65fh6BVtmjUc=
+github.com/kubevela/pkg v1.10.0/go.mod h1:EmM4VIyU7KxDmPBq9hG4GpSZbGwiM76/W/8paLBk8wY=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lib/pq v1.10.7 h1:p7ZhMD+KsSRozJr34udlUrhboJwWAgCg34+/ZZNvZZw=


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade `github.com/kubevela/pkg` to v1.10.0 to use the latest stable release. Replaces the pseudo-version in go.mod and updates go.sum; no code changes.

<sup>Written for commit 4b83355c828ccfd957808e93e3e00311f503ad65. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

