### PR TITLE
Feat: make reconcile timeout configurable via --reconcile-timeout flag

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -111,6 +111,7 @@ func main() {
 	flag.IntVar(&webhookPort, "webhook-port", 9443, "admission webhook listen address")
 	flag.IntVar(&controllerArgs.ConcurrentReconciles, "concurrent-reconciles", 4, "concurrent-reconciles is the concurrent reconcile number of the controller. The default value is 4")
 	flag.BoolVar(&controllerArgs.IgnoreWorkflowWithoutControllerRequirement, "ignore-workflow-without-controller-requirement", false, "If true, workflow controller will not process the workflowrun without 'workflowrun.oam.dev/controller-version-require' annotation")
+	flag.DurationVar(&controllerArgs.ReconcileTimeout, "reconcile-timeout", controllers.DefaultReconcileTimeout, "The timeout for workflowrun reconcile loop. Increase this value if your workflowrun has a large number of steps. Default is 3m.")
 	flag.Float64Var(&qps, "kube-api-qps", 50, "the qps for reconcile clients. Low qps may lead to low throughput. High qps may give stress to api-server. Raise this value if concurrent-reconciles is set to be high.")
 	flag.IntVar(&burst, "kube-api-burst", 100, "the burst for reconcile clients. Recommend setting it qps*2.")
 	flag.StringVar(&userAgent, "user-agent", "vela-workflow", "the user agent of the client.")

--- a/controllers/backup_controller.go
+++ b/controllers/backup_controller.go
@@ -68,7 +68,11 @@ const (
 // +kubebuilder:rbac:groups=core.oam.dev,resources=workflowruns/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=core.oam.dev,resources=workflowruns/finalizers,verbs=update
 func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	ctx, cancel := context.WithTimeout(ctx, ReconcileTimeout)
+	reconcileTimeout := r.Args.ReconcileTimeout
+	if reconcileTimeout <= 0 {
+		reconcileTimeout = DefaultReconcileTimeout
+	}
+	ctx, cancel := context.WithTimeout(ctx, reconcileTimeout)
 	defer cancel()
 
 	ctx = types.SetNamespaceInCtx(ctx, req.Namespace)

--- a/controllers/workflowrun_controller.go
+++ b/controllers/workflowrun_controller.go
@@ -58,6 +58,8 @@ type Args struct {
 	ConcurrentReconciles int
 	// IgnoreWorkflowWithoutControllerRequirement indicates that workflow controller will not process the workflowrun without 'workflowrun.oam.dev/controller-version-require' annotation.
 	IgnoreWorkflowWithoutControllerRequirement bool
+	// ReconcileTimeout is the timeout for the reconcile loop. Default is 3 minutes.
+	ReconcileTimeout time.Duration
 }
 
 // WorkflowRunReconciler reconciles a WorkflowRun object
@@ -74,9 +76,9 @@ type workflowRunPatcher struct {
 	run *v1alpha1.WorkflowRun
 }
 
-var (
-	// ReconcileTimeout timeout for controller to reconcile
-	ReconcileTimeout = time.Minute * 3
+const (
+	// DefaultReconcileTimeout is the default timeout for controller to reconcile
+	DefaultReconcileTimeout = time.Minute * 3
 )
 
 // Reconcile reconciles the WorkflowRun object
@@ -84,7 +86,11 @@ var (
 // +kubebuilder:rbac:groups=core.oam.dev,resources=workflowruns/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=core.oam.dev,resources=workflowruns/finalizers,verbs=update
 func (r *WorkflowRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	ctx, cancel := context.WithTimeout(ctx, ReconcileTimeout)
+	reconcileTimeout := r.Args.ReconcileTimeout
+	if reconcileTimeout <= 0 {
+		reconcileTimeout = DefaultReconcileTimeout
+	}
+	ctx, cancel := context.WithTimeout(ctx, reconcileTimeout)
 	defer cancel()
 
 	ctx = types.SetNamespaceInCtx(ctx, req.Namespace)


### PR DESCRIPTION
## Problem

  WorkflowRun reconcile timeout is hardcoded to 3 minutes in
  `controllers/workflowrun_controller.go`. There is no way to configure
  this value at runtime, which causes failures for large workflowruns
  (1000+ steps):

  failed to patch workflowrun status: client rate limiter Wait returned
  an error: context deadline exceeded

  The reconcile context expires at exactly 3 minutes, and the final
  `patchStatus` call fails because the context is already dead when the
  rate limiter's `Wait(ctx)` checks it.

  ## Solution

  - Add `ReconcileTimeout time.Duration` to `Args` struct
  - Expose `--reconcile-timeout` flag (default: `3m` to preserve backward compatibility)
  - Use `r.Args.ReconcileTimeout` in Reconcile function

  ## Usage

  ```bash
  --reconcile-timeout=30m

  Backward Compatibility

  Default value remains 3m. No breaking change.

  ---

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the reconcile timeout configurable via the `--reconcile-timeout` flag to avoid context deadline exceeded errors on large workflow runs. Default stays 3m; behavior is unchanged unless you set it.

- **New Features**
  - Added `ReconcileTimeout` to `controllers.Args` and a `--reconcile-timeout` flag in `cmd/main.go` (default: `controllers.DefaultReconcileTimeout`, 3m).
  - `WorkflowRunReconciler` and `BackupReconciler` now use the configured timeout, falling back to `controllers.DefaultReconcileTimeout` if unset or invalid. Example: `--reconcile-timeout=30m`.

<sup>Written for commit 80708858888a0a3f2f460c8397e3aba9b769824f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kubevela/workflow/pull/228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

