### PR TITLE
Fix: register oam/v1alpha1 types on manager scheme for workflowRef

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -48,6 +48,7 @@ import (
 	crtlwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	triggerv1alpha1 "github.com/kubevela/kube-trigger/api/v1alpha1"
+	oamv1alpha1 "github.com/kubevela/pkg/apis/oam/v1alpha1"
 	velaclient "github.com/kubevela/pkg/controller/client"
 	"github.com/kubevela/pkg/multicluster"
 
@@ -75,6 +76,7 @@ func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
 	utilruntime.Must(v1alpha1.AddToScheme(scheme))
+	utilruntime.Must(oamv1alpha1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 

--- a/e2e/definition_test.go
+++ b/e2e/definition_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"time"
 
+	oamv1alpha1 "github.com/kubevela/pkg/apis/oam/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -76,11 +77,37 @@ var _ = Describe("Test the workflow run with the built-in definitions", func() {
 			time.Second*30, time.Second*2).Should(Equal(v1alpha1.WorkflowStateSucceeded))
 	})
 
+	It("Test the workflow run that references a Workflow template via workflowRef", func() {
+		applyWorkflowFromYAML(ctx, "./test-data/ref-workflow-template.yaml", namespace)
+		wr := applyWorkflowRunFromYAML(ctx, "./test-data/ref-workflow-run.yaml", namespace)
+		Eventually(
+			func() v1alpha1.WorkflowRunPhase {
+				var getWorkflow v1alpha1.WorkflowRun
+				if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: wr.Name}, &getWorkflow); err != nil {
+					klog.Errorf("fail to query the app %s", err.Error())
+				}
+				klog.Infof("the workflow run status is %s (%+v)", getWorkflow.Status.Phase, getWorkflow.Status.Steps)
+				return getWorkflow.Status.Phase
+			},
+			time.Second*30, time.Second*2).Should(Equal(v1alpha1.WorkflowStateSucceeded))
+	})
+
 	AfterEach(func() {
 		By("Clean up resources after a test")
 		k8sClient.DeleteAllOf(ctx, &v1alpha1.WorkflowRun{}, client.InNamespace(namespace))
+		k8sClient.DeleteAllOf(ctx, &oamv1alpha1.Workflow{}, client.InNamespace(namespace))
 	})
 })
+
+func applyWorkflowFromYAML(ctx context.Context, path, ns string) oamv1alpha1.Workflow {
+	content, err := os.ReadFile(path)
+	Expect(err).Should(BeNil())
+	var workflow oamv1alpha1.Workflow
+	Expect(yaml.Unmarshal(content, &workflow)).Should(BeNil())
+	workflow.Namespace = ns
+	Expect(k8sClient.Create(ctx, &workflow)).Should(SatisfyAny(BeNil(), &utils.AlreadyExistMatcher{}))
+	return workflow
+}
 
 func applyWorkflowRunFromYAML(ctx context.Context, path, ns string) v1alpha1.WorkflowRun {
 	content, err := os.ReadFile(path)

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
+	oamv1alpha1 "github.com/kubevela/pkg/apis/oam/v1alpha1"
 	"github.com/kubevela/pkg/util/singleton"
 	"github.com/kubevela/pkg/util/test/definition"
 
@@ -46,6 +47,7 @@ func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
 	utilruntime.Must(v1alpha1.AddToScheme(scheme))
+	utilruntime.Must(oamv1alpha1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 

--- a/e2e/test-data/ref-workflow-run.yaml
+++ b/e2e/test-data/ref-workflow-run.yaml
@@ -1,0 +1,7 @@
+apiVersion: core.oam.dev/v1alpha1
+kind: WorkflowRun
+metadata:
+  name: message-ref
+  namespace: default
+spec:
+  workflowRef: message-template

--- a/e2e/test-data/ref-workflow-template.yaml
+++ b/e2e/test-data/ref-workflow-template.yaml
@@ -1,0 +1,10 @@
+apiVersion: core.oam.dev/v1alpha1
+kind: Workflow
+metadata:
+  name: message-template
+  namespace: default
+steps:
+  - name: step1
+    type: message
+    properties:
+      message: "hello"


### PR DESCRIPTION
Fixes #230

WorkflowRuns that use spec.workflowRef are rejected by the validating webhook with:

field "spec.workflowRef": Invalid value error encountered, failed to get workflow ref:
no kind is registered for the type v1alpha1.Workflow in scheme "pkg/runtime/scheme.go:100"

Problem. The standalone Workflow type was moved to github.com/kubevela/pkg/apis/oam/v1alpha1 (pkg bump to v1.10.0). pkg/generator/generator.go and pkg/webhook/v1alpha1/workflowrun/validation.go resolve workflowRef via oamv1alpha1.Workflow, but oamv1alpha1.AddToScheme was never wired into the manager scheme in cmd/main.go (only clientgoscheme, the local v1alpha1, and conditionally kube-trigger are registered). The moved package registers itself into the global k8sscheme.Scheme, but the manager builds its own runtime.NewScheme(), so the type stays unknown — and client.Get(&oamv1alpha1.Workflow{}) fails in scheme.ObjectKinds. This affects both the webhook and the reconcile path, since both call generator.GenerateWorkflowInstance.

Solution. Register the moved package on the manager scheme:

utilruntime.Must(oamv1alpha1.AddToScheme(scheme))

oamv1alpha1 shares the GroupVersion core.oam.dev/v1alpha1 with the local package and registers complementary kinds (Definition, Workflow, WorkflowList) with no overlap against the local WorkflowRun, so co-registration is safe.

Key files
- cmd/main.go — register oamv1alpha1 on the manager scheme.
- e2e/ — register oamv1alpha1 in the suite scheme; new e2e spec covering workflowRef; two test-data manifests (a Workflow template + a WorkflowRun referencing it).

Breaking changes: none.

How has this code been tested

- New e2e spec "Test the workflow run that references a Workflow template via workflowRef" creates a Workflow template and a WorkflowRun that references it, asserting the run reaches succeeded. Full suite passes locally against a k3d cluster (go test -v ./e2e -run TestE2e → 3/3 specs).
- Existing unit/integration tests pass; go vet ./... and gofmt clean.
- Manually verified on a local cluster: applying a WorkflowRun with workflowRef is now admitted and runs to completion.

Special notes for your reviewer

The reason this regression slipped past CI: existing webhook tests only exercise the inline workflowSpec branch of ValidateWorkflow, so the workflowRef Get path had no coverage. The added e2e spec closes that gap by running against the real manager scheme.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes webhook and reconcile failures when a WorkflowRun uses spec.workflowRef by registering `github.com/kubevela/pkg/apis/oam/v1alpha1` types on the manager scheme. WorkflowRefs are now admitted and run to completion (fixes #230).

- **Bug Fixes**
  - Register `oamv1alpha1.AddToScheme` in `cmd/main.go` and the e2e suite.
  - Add an e2e test with sample manifests to validate `workflowRef` resolution.
  - No breaking changes.

<sup>Written for commit 84d7e1f1a9e99ba441775fa46737d23798d4183b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kubevela/workflow/pull/231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

