### PR TITLE
Fix: use triggering tag for chart version

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -4,7 +4,12 @@ on:
   push:
     tags:
       - "v*"
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      overwrite_version:
+        description: 'Version to overwrite (e.g. v0.6.3). Leave empty to fail if version already exists.'
+        required: false
+        default: ''
 
 jobs:
   publish-images:
@@ -31,6 +36,18 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Check image does not already exist
+        run: |
+          TAG=${{ steps.vars.outputs.TAG }}
+          if [[ "$TAG" != "latest" ]]; then
+            if docker manifest inspect docker.io/oamdev/vela-workflow:${TAG} > /dev/null 2>&1; then
+              if [[ "${{ inputs.overwrite_version }}" != "$TAG" ]]; then
+                echo "Image oamdev/vela-workflow:${TAG} already exists. Set overwrite_version=${TAG} to republish."
+                exit 1
+              fi
+              echo "Image already exists but overwrite_version matches, continuing."
+            fi
+          fi
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
         with:
@@ -86,7 +103,7 @@ jobs:
           patch="0"
           current_repo_tag="$major.$minor.$patch"
           image_tag=${GITHUB_REF#refs/tags/}
-          chart_version=$latest_repo_tag
+          chart_version=$image_tag
           if [[ ${GITHUB_REF} == "refs/heads/main" ]]; then
             image_tag=latest
             chart_version=${current_repo_tag}-nightly-build
@@ -106,6 +123,15 @@ jobs:
           git config --global user.email "135009839+kubevela[bot]@users.noreply.github.com"
           git config --global user.name "kubevela[bot]"
           git clone https://x-access-token:${{ steps.get_app_token.outputs.token }}@github.com/kubevela/charts.git kubevela-charts
+          chart_version=${GITHUB_REF#refs/tags/}
+          chart_semver=${chart_version#"v"}
+          if ls kubevela-charts/docs/vela-workflow-${chart_semver}.tgz > /dev/null 2>&1; then
+            if [[ "${{ inputs.overwrite_version }}" != "${chart_version}" ]]; then
+              echo "Helm chart vela-workflow-${chart_semver} already exists. Set overwrite_version=${chart_version} to republish."
+              exit 1
+            fi
+            echo "Chart already exists but overwrite_version matches, continuing."
+          fi
           helm package $HELM_CHART --destination ./kubevela-charts/docs/
           helm repo index --url https://kubevela.github.io/charts ./kubevela-charts/docs/
           cd kubevela-charts/


### PR DESCRIPTION
…or chart version


### Description of your changes

- Fix chart version using latest tag lookup instead of the triggering tag, which could cause older versions to be overwritten (e.g. publishing v0.6.4 overwrote the v0.6.3 chart)  
  - Add existence checks for both the Docker image and Helm chart before publishing; fails fast if the version is already published                                                  
  - Add `overwrite_version` workflow_dispatch input requiring the user to explicitly type the version they intend to overwrite, preventing accidental republishes 

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

N/A - Github Action only


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop accidental overwrites when republishing Docker images and Helm charts. Use the triggering tag for the chart version and require an explicit override to republish an existing version.

- **Bug Fixes**
  - Use the Git tag that triggered the workflow for `chart_version` (no more latest-tag lookup that could overwrite older charts).
  - Fail fast if Docker image `oamdev/vela-workflow:<tag>` or Helm chart `vela-workflow-<semver>.tgz` already exists.
  - Add `workflow_dispatch` input `overwrite_version`; must match the tag to allow republishing.

<sup>Written for commit 6d7e9d2f8330d87eb3a8c6897fbe655866aedd2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kubevela/workflow/pull/232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

