### PR TITLE
Feat: add envVar and CUE_EXPERIMENT feature gate to vela-workflow

### DIFF
--- a/charts/vela-workflow/README.md
+++ b/charts/vela-workflow/README.md
@@ -74,6 +74,8 @@ helm install --create-namespace -n vela-system workflow kubevela/vela-workflow -
 | `resources.limits.memory`   | Workflow controller's memory limit   | `1Gi`                  |
 | `resources.requests.cpu`    | Workflow controller's cpu request    | `50m`                  |
 | `resources.requests.memory` | Workflow controller's memory request | `20Mi`                 |
+| `envVar`                    | Extra environment variables injected into the workflow controller container (always applied) | `[]`             |
+| `featureGates.enableCueExpVariable` | inject the CUE_EXPERIMENT env var (evalv3=0,keepvalidators=0) into the controller to disable experimental CUE features during the v0.14.x migration window | `true`      |
 | `webhookService.type`       | KubeVela webhook service type        | `ClusterIP`            |
 | `webhookService.port`       | KubeVela webhook service port        | `9443`                 |
 | `healthCheck.port`          | KubeVela health check port           | `9440`                 |

--- a/charts/vela-workflow/templates/workflow-controller.yaml
+++ b/charts/vela-workflow/templates/workflow-controller.yaml
@@ -156,6 +156,16 @@ spec:
             {{ end }}
           image: {{ .Values.imageRegistry }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ quote .Values.image.pullPolicy }}
+          {{- if or .Values.envVar .Values.featureGates.enableCueExpVariable }}
+          env:
+          {{- with .Values.envVar }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.featureGates.enableCueExpVariable }}
+            - name: CUE_EXPERIMENT
+              value: "evalv3=0,keepvalidators=0"
+          {{- end }}
+          {{- end }}
           resources:
           {{- toYaml .Values.resources | nindent 12 }}
           {{ if .Values.admissionWebhooks.enabled }}

--- a/charts/vela-workflow/values.yaml
+++ b/charts/vela-workflow/values.yaml
@@ -87,6 +87,13 @@ resources:
     cpu: 50m
     memory: 20Mi
 
+## @param envVar Extra environment variables injected into the workflow controller container (always applied)
+envVar: []
+
+## @param featureGates.enableCueExpVariable inject the CUE_EXPERIMENT env var (evalv3=0,keepvalidators=0) into the controller to disable experimental CUE features during the v0.14.x migration window
+featureGates:
+  enableCueExpVariable: true
+
 ## @param webhookService.type KubeVela webhook service type
 ## @param webhookService.port KubeVela webhook service port
 webhookService:


### PR DESCRIPTION
Summary

- Adds an envVar value to the vela-workflow chart, injected into the controller container via the standard {{- with .Values.envVar }} / toYaml | nindent pattern — arbitrary env vars set through Helm, always applied.
- Adds a featureGates.enableCueExpVariable flag (default true) that additionally injects CUE_EXPERIMENT=evalv3=0,keepvalidators=0 to disable the experimental CUE features that break existing definitions during the CUE v0.14.x migration.

Problem

Workflow bundles CUE v0.14.1, which enables two experimental features by default (evalv3, keepvalidators) that break existing definitions. They can be turned off with CUE_EXPERIMENT=evalv3=0,keepvalidators=0, but the chart offered no way to set it — operators had to hand-patch the deployment after every Helm upgrade, and the patch didn't survive the next one.

Solution

- values.yaml: new envVar: [] and a featureGates block with enableCueExpVariable: true.
- workflow-controller.yaml: render env: when either envVar is non-empty or the flag is on; inject envVar first, then CUE_EXPERIMENT when the flag is true.
- README.md: add the envVar and featureGates.enableCueExpVariable rows.

The flag and envVar are independent — disabling the flag only drops the CUE_EXPERIMENT entry and leaves any user-provided envVar values intact.

Key files

- charts/vela-workflow/values.yaml
- charts/vela-workflow/templates/workflow-controller.yaml
- charts/vela-workflow/README.md

Breaking changes

None to the chart API. Default behavior change: the controller now runs with CUE_EXPERIMENT=evalv3=0,keepvalidators=0 unless featureGates.enableCueExpVariable=false.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Helm values to inject extra env vars into the `vela-workflow` controller and a feature gate to set `CUE_EXPERIMENT=evalv3=0,keepvalidators=0` to keep existing definitions working during the CUE v0.14.x migration. This removes the need for manual post-upgrade patches.

- **New Features**
  - `envVar`: array of extra environment variables applied to the controller.
  - `featureGates.enableCueExpVariable`: toggles injection of `CUE_EXPERIMENT` into the controller.
  - Chart renders `env:` only when needed; user-provided `envVar` entries are preserved.

- **Migration**
  - Default now injects `CUE_EXPERIMENT=evalv3=0,keepvalidators=0`. Set `featureGates.enableCueExpVariable=false` to opt out.

<sup>Written for commit 0efe893c4f8dbbfd6205bb5fc3b0d5a9d31cb522. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kubevela/workflow/pull/234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

