### PR TITLE
[Backport release-0.6] Feat: add ConfigMap-driven workflow HTTP denylist

### DIFF
--- a/charts/vela-workflow/README.md
+++ b/charts/vela-workflow/README.md
@@ -38,16 +38,18 @@ helm install --create-namespace -n vela-system workflow kubevela/vela-workflow -
 
 ### KubeVela workflow parameters
 
-| Name                                   | Description                                                                                                                                                                            | Value                   |
-| -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
-| `workflow.enableSuspendOnFailure`      | Enable the capability of suspend an failed workflow automatically                                                                                                                      | `false`                 |
-| `workflow.enablePatchStatusAtOnce`     | Enable the capability of patch status at once                                                                                                                                          | `false`                 |
-| `workflow.enableWatchEventListener`    | Enable the capability of watch event listener for a faster reconcile, note that you need to install [kube-trigger](https://github.com/kubevela/kube-trigger) first to use this feature | `false`                 |
-| `workflow.backoff.maxTime.waitState`   | The max backoff time of workflow in a wait condition                                                                                                                                   | `60`                    |
-| `workflow.backoff.maxTime.failedState` | The max backoff time of workflow in a failed condition                                                                                                                                 | `300`                   |
-| `workflow.step.errorRetryTimes`        | The max retry times of a failed workflow step                                                                                                                                          | `10`                    |
-| `workflow.groupByLabel`                | The label used to group workflow record                                                                                                                                                | `pipeline.oam.dev/name` |
-
+| Name                                                    | Description                                                                                                                                                                            | Value                   |
+| ------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| `workflow.enableSuspendOnFailure`                       | Enable the capability of suspend an failed workflow automatically                                                                                                                      | `false`                 |
+| `workflow.enablePatchStatusAtOnce`                      | Enable the capability of patch status at once                                                                                                                                          | `false`                 |
+| `workflow.enableWatchEventListener`                     | Enable the capability of watch event listener for a faster reconcile, note that you need to install [kube-trigger](https://github.com/kubevela/kube-trigger) first to use this feature | `false`                 |
+| `workflow.disableWorkflowHTTP`                          | Disable outbound HTTP from workflow request/webhook steps                                                                                                                               | `false`                 |
+| `workflow.blockPrivateHTTPAddresses`                    | Block outbound HTTP to RFC-1918 and ULA destinations                                                                                                                                   | `false`                 |
+| `workflow.httpDeny.configMapName`                       | ConfigMap name in the controller namespace containing extra HTTP denylist entries (`denyCIDRs`, `denyHosts`)                                                                           | `""`                    |
+| `workflow.backoff.maxTime.waitState`                    | The max backoff time of workflow in a wait condition                                                                                                                                   | `60`                    |
+| `workflow.backoff.maxTime.failedState`                  | The max backoff time of workflow in a failed condition                                                                                                                                 | `300`                   |
+| `workflow.step.errorRetryTimes`                         | The max retry times of a failed workflow step                                                                                                                                          | `10`                    |
+| `workflow.groupByLabel`                                 | The label used to group workflow record                                                                                                                                                | `pipeline.oam.dev/name` |
 
 ### KubeVela workflow backup parameters
 

--- a/charts/vela-workflow/templates/workflow-controller.yaml
+++ b/charts/vela-workflow/templates/workflow-controller.yaml
@@ -141,6 +141,11 @@ spec:
             - "--feature-gates=EnablePatchStatusAtOnce={{- .Values.workflow.enablePatchStatusAtOnce | toString -}}"
             - "--feature-gates=EnableSuspendOnFailure={{- .Values.workflow.enableSuspendOnFailure | toString -}}"
             - "--feature-gates=EnableBackupWorkflowRecord={{- .Values.backup.enabled | toString -}}"
+            - "--feature-gates=DisableWorkflowHTTP={{- .Values.workflow.disableWorkflowHTTP | toString -}}"
+            - "--feature-gates=BlockPrivateHTTPAddresses={{- .Values.workflow.blockPrivateHTTPAddresses | toString -}}"
+            {{ if .Values.workflow.httpDeny.configMapName }}
+            - "--workflow-http-deny-configmap-name={{ .Values.workflow.httpDeny.configMapName }}"
+            {{ end }}
             - "--group-by-label={{ .Values.workflow.groupByLabel }}"
             {{ if .Values.backup.enable }}
             - "--backup-strategy={{ .Values.backup.strategy }}"
@@ -152,6 +157,12 @@ spec:
             {{ end }}
           image: {{ .Values.imageRegistry }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ quote .Values.image.pullPolicy }}
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
           resources:
           {{- toYaml .Values.resources | nindent 12 }}
           {{ if .Values.admissionWebhooks.enabled }}

--- a/charts/vela-workflow/values.yaml
+++ b/charts/vela-workflow/values.yaml
@@ -17,6 +17,9 @@ ignoreWorkflowWithoutControllerRequirement: false
 ## @param workflow.enableSuspendOnFailure Enable the capability of suspend an failed workflow automatically
 ## @param workflow.enablePatchStatusAtOnce Enable the capability of patch status at once
 ## @param workflow.enableWatchEventListener Enable the capability of watch event listener for a faster reconcile, note that you need to install [kube-trigger](https://github.com/kubevela/kube-trigger) first to use this feature
+## @param workflow.disableWorkflowHTTP Disable outbound HTTP from workflow request/webhook steps
+## @param workflow.blockPrivateHTTPAddresses Block outbound HTTP to RFC-1918 and ULA destinations
+## @param workflow.httpDeny.configMapName ConfigMap name in controller namespace containing extra HTTP denylist entries
 ## @param workflow.backoff.maxTime.waitState The max backoff time of workflow in a wait condition
 ## @param workflow.backoff.maxTime.failedState The max backoff time of workflow in a failed condition
 ## @param workflow.step.errorRetryTimes The max retry times of a failed workflow step
@@ -25,6 +28,10 @@ workflow:
   enableSuspendOnFailure: false
   enablePatchStatusAtOnce: false
   enableWatchEventListener: false 
+  disableWorkflowHTTP: false
+  blockPrivateHTTPAddresses: false
+  httpDeny:
+    configMapName: ""
   backoff:
     maxTime:
       waitState: 60

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -58,6 +58,7 @@ import (
 	"github.com/kubevela/workflow/pkg/monitor/watcher"
 	"github.com/kubevela/workflow/pkg/types"
 	"github.com/kubevela/workflow/pkg/utils"
+	"github.com/kubevela/workflow/pkg/utils/httpguard"
 	"github.com/kubevela/workflow/pkg/webhook"
 	"github.com/kubevela/workflow/version"
 	//+kubebuilder:scaffold:imports
@@ -79,6 +80,7 @@ func init() {
 func main() {
 	var metricsAddr, logFilePath, probeAddr, pprofAddr, leaderElectionResourceLock, userAgent, certDir string
 	var backupStrategy, backupIgnoreStrategy, backupPersistType, groupByLabel, backupConfigSecretName, backupConfigSecretNamespace string
+	var workflowHTTPDenyConfigMapName string
 	var enableLeaderElection, useWebhook, logDebug, backupCleanOnBackup bool
 	var qps float64
 	var logFileMaxSize uint64
@@ -123,6 +125,7 @@ func main() {
 	flag.BoolVar(&backupCleanOnBackup, "backup-clean-on-backup", false, "Set the auto clean for backup workflow records, default is false")
 	flag.StringVar(&backupConfigSecretName, "backup-config-secret-name", "backup-config", "Set the secret name for backup workflow configs, default is backup-config")
 	flag.StringVar(&backupConfigSecretNamespace, "backup-config-secret-namespace", "vela-system", "Set the secret namespace for backup workflow configs, default is backup-config")
+	flag.StringVar(&workflowHTTPDenyConfigMapName, "workflow-http-deny-configmap-name", "", "ConfigMap name (in controller namespace) containing workflow HTTP denylist")
 	multicluster.AddClusterGatewayClientFlags(flag.CommandLine)
 	feature.DefaultMutableFeatureGate.AddFlag(flag.CommandLine)
 	sharding.AddControllerFlags(flag.CommandLine)
@@ -215,6 +218,21 @@ func main() {
 	}
 
 	kubeClient := mgr.GetClient()
+	controllerNamespace := resolveControllerNamespace()
+	httpguard.SetEnhancer(func(p httpguard.Policy) httpguard.Policy {
+		if feature.DefaultMutableFeatureGate.Enabled(features.BlockPrivateHTTPAddresses) {
+			p.BlockPrivate = true
+		}
+		return p
+	})
+	if err := httpguard.LoadConfigMap(context.Background(), kubeClient, workflowHTTPDenyConfigMapName, controllerNamespace); err != nil {
+		klog.ErrorS(err, "unable to initialize workflow HTTP deny ConfigMap", "name", workflowHTTPDenyConfigMapName, "namespace", controllerNamespace)
+		os.Exit(1)
+	}
+	if err := httpguard.SetupWatcher(mgr, workflowHTTPDenyConfigMapName, controllerNamespace); err != nil {
+		klog.ErrorS(err, "unable to watch workflow HTTP deny ConfigMap", "name", workflowHTTPDenyConfigMapName, "namespace", controllerNamespace)
+		os.Exit(1)
+	}
 	if groupByLabel != "" {
 		if err := mgr.Add(utils.NewRecycleCronJob(kubeClient, recycleDuration, "0 0 * * *", groupByLabel)); err != nil {
 			klog.Error(err, "unable to start recycle cronjob")
@@ -360,4 +378,11 @@ func waitWebhookSecretVolume(certDir string, timeout, interval time.Duration) er
 			}
 		}
 	}
+}
+
+func resolveControllerNamespace() string {
+	if ns := strings.TrimSpace(os.Getenv("POD_NAMESPACE")); ns != "" {
+		return ns
+	}
+	return "vela-system"
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -225,7 +225,8 @@ func main() {
 		}
 		return p
 	})
-	if err := httpguard.LoadConfigMap(context.Background(), kubeClient, workflowHTTPDenyConfigMapName, controllerNamespace); err != nil {
+	// Use APIReader: mgr.GetClient() is cache-backed and is not ready before mgr.Start.
+	if err := httpguard.LoadConfigMap(context.Background(), mgr.GetAPIReader(), workflowHTTPDenyConfigMapName, controllerNamespace); err != nil {
 		klog.ErrorS(err, "unable to initialize workflow HTTP deny ConfigMap", "name", workflowHTTPDenyConfigMapName, "namespace", controllerNamespace)
 		os.Exit(1)
 	}

--- a/pkg/features/controller_features.go
+++ b/pkg/features/controller_features.go
@@ -31,6 +31,10 @@ const (
 	EnablePatchStatusAtOnce featuregate.Feature = "EnablePatchStatusAtOnce"
 	// EnableWatchEventListener enable watch event listener
 	EnableWatchEventListener featuregate.Feature = "EnableWatchEventListener"
+	// DisableWorkflowHTTP disables outbound HTTP from workflow steps.
+	DisableWorkflowHTTP featuregate.Feature = "DisableWorkflowHTTP"
+	// BlockPrivateHTTPAddresses blocks RFC-1918/ULA destinations for workflow HTTP.
+	BlockPrivateHTTPAddresses featuregate.Feature = "BlockPrivateHTTPAddresses"
 )
 
 var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
@@ -38,6 +42,8 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	EnableBackupWorkflowRecord: {Default: false, PreRelease: featuregate.Alpha},
 	EnablePatchStatusAtOnce:    {Default: false, PreRelease: featuregate.Alpha},
 	EnableWatchEventListener:   {Default: false, PreRelease: featuregate.Alpha},
+	DisableWorkflowHTTP:        {Default: false, PreRelease: featuregate.Alpha},
+	BlockPrivateHTTPAddresses:  {Default: false, PreRelease: featuregate.Alpha},
 }
 
 func init() {

--- a/pkg/providers/http/do.go
+++ b/pkg/providers/http/do.go
@@ -24,20 +24,24 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	neturl "net/url"
 	"strings"
 	"time"
 
 	"cuelang.org/go/cue"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	monitorContext "github.com/kubevela/pkg/monitor/context"
 
 	wfContext "github.com/kubevela/workflow/pkg/context"
 	"github.com/kubevela/workflow/pkg/cue/model/value"
+	"github.com/kubevela/workflow/pkg/features"
 	"github.com/kubevela/workflow/pkg/providers/http/ratelimiter"
 	"github.com/kubevela/workflow/pkg/types"
+	"github.com/kubevela/workflow/pkg/utils/httpguard"
 )
 
 const (
@@ -51,6 +55,14 @@ var (
 
 func init() {
 	rateLimiter = ratelimiter.NewRateLimiter(128)
+}
+
+func requestPolicy() httpguard.Policy {
+	policy := httpguard.Current()
+	if utilfeature.DefaultMutableFeatureGate.Enabled(features.BlockPrivateHTTPAddresses) {
+		policy.BlockPrivate = true
+	}
+	return policy
 }
 
 type provider struct {
@@ -68,15 +80,22 @@ func (h *provider) Do(ctx monitorContext.Context, wfCtx wfContext.Context, v *va
 }
 
 func (h *provider) runHTTP(ctx monitorContext.Context, v *value.Value) (interface{}, error) {
+	if utilfeature.DefaultMutableFeatureGate.Enabled(features.DisableWorkflowHTTP) {
+		return nil, errors.New("workflow outbound HTTP is disabled by DisableWorkflowHTTP feature gate")
+	}
 	var (
 		err             error
 		method, u       string
 		header, trailer http.Header
 		r               io.Reader
 	)
+	policy := requestPolicy()
 	defaultClient := &http.Client{
-		Transport: http.DefaultTransport,
+		Transport: httpguard.SecureTransport(http.DefaultTransport.(*http.Transport).Clone(), policy),
 		Timeout:   time.Second * 3,
+		CheckRedirect: func(req *http.Request, _ []*http.Request) error {
+			return policy.BlockedHost(req.URL.Host)
+		},
 	}
 	if timeout, err := v.GetString("request", "timeout"); err == nil && timeout != "" {
 		duration, err := time.ParseDuration(timeout)
@@ -90,6 +109,11 @@ func (h *provider) runHTTP(ctx monitorContext.Context, v *value.Value) (interfac
 	}
 	if u, err = v.GetString("url"); err != nil {
 		return nil, err
+	}
+	if parsed, err := neturl.Parse(u); err == nil {
+		if err := policy.BlockedHost(parsed.Host); err != nil {
+			return nil, err
+		}
 	}
 	if rl, err := v.LookupValue("request", "ratelimiter"); err == nil {
 		limit, err := rl.GetInt64("limit")
@@ -133,7 +157,11 @@ func (h *provider) runHTTP(ctx monitorContext.Context, v *value.Value) (interfac
 	req.Trailer = trailer
 
 	if tr, err := h.getTransport(ctx, v); err == nil && tr != nil {
-		defaultClient.Transport = tr
+		if transport, ok := tr.(*http.Transport); ok {
+			defaultClient.Transport = httpguard.SecureTransport(transport, policy)
+		} else {
+			defaultClient.Transport = tr
+		}
 	}
 
 	resp, err := defaultClient.Do(req)

--- a/pkg/providers/http/do_test.go
+++ b/pkg/providers/http/do_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/kubevela/workflow/pkg/providers"
 	"github.com/kubevela/workflow/pkg/providers/http/ratelimiter"
 	"github.com/kubevela/workflow/pkg/providers/http/testdata"
+	"github.com/kubevela/workflow/pkg/utils/httpguard"
 )
 
 func TestHttpDo(t *testing.T) {
@@ -312,6 +313,31 @@ url: "https://127.0.0.1:8443/api/v1/token?val=test-token"
 	prd := &provider{cli, "default"}
 	err = prd.Do(ctx, nil, v, nil)
 	r.NoError(err)
+}
+
+func TestHttpDoBlocksDeniedHost(t *testing.T) {
+	ctx := monitorContext.NewTraceContext(context.Background(), "")
+	httpguard.SetDenyFragment(httpguard.Policy{
+		ExactHosts: map[string]struct{}{"blocked.example.com": {}},
+	})
+	defer httpguard.SetDenyFragment(httpguard.Policy{ExactHosts: map[string]struct{}{}})
+
+	v, err := value.NewValue(`
+method: "GET"
+url: "http://blocked.example.com/path"
+response: close({
+	body: string
+	header?:  [string]: [...string]
+	trailer?: [string]: [...string]
+	statusCode: int
+})
+`, nil, "")
+	require.NoError(t, err)
+
+	prd := &provider{}
+	err = prd.Do(ctx, nil, v, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "blocked SSRF host")
 }
 
 func newMockHttpsServer() *httptest.Server {

--- a/pkg/utils/httpguard/deny_config.go
+++ b/pkg/utils/httpguard/deny_config.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package httpguard
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	// ConfigMapKeyDenyCIDRs is the ConfigMap data key for CIDR/IP denylist lines.
+	ConfigMapKeyDenyCIDRs = "denyCIDRs"
+	// ConfigMapKeyDenyHosts is the ConfigMap data key for hostname denylist lines.
+	ConfigMapKeyDenyHosts = "denyHosts"
+)
+
+// ParseDenyList parses denyCIDRs and denyHosts text blobs into a Policy fragment
+// that only carries denylist fields. Blank lines and # comments are ignored.
+func ParseDenyList(cidrsText, hostsText string) (Policy, error) {
+	out := Policy{ExactHosts: map[string]struct{}{}}
+	if err := parseCIDRLines(cidrsText, &out); err != nil {
+		return Policy{}, err
+	}
+	if err := parseHostLines(hostsText, &out); err != nil {
+		return Policy{}, err
+	}
+	return out, nil
+}
+
+// ParseConfigMap builds a denylist Policy fragment from a ConfigMap.
+func ParseConfigMap(cm *corev1.ConfigMap) (Policy, error) {
+	if cm == nil {
+		return Policy{ExactHosts: map[string]struct{}{}}, nil
+	}
+	return ParseDenyList(cm.Data[ConfigMapKeyDenyCIDRs], cm.Data[ConfigMapKeyDenyHosts])
+}
+
+func parseCIDRLines(text string, out *Policy) error {
+	return forEachEntry(text, func(line string) error {
+		if ip := net.ParseIP(line); ip != nil {
+			out.ExactIPs = append(out.ExactIPs, ip.To16())
+			return nil
+		}
+		_, network, err := net.ParseCIDR(line)
+		if err != nil {
+			return fmt.Errorf("invalid deny CIDR %q: %w", line, err)
+		}
+		out.DenyCIDRs = append(out.DenyCIDRs, network)
+		return nil
+	})
+}
+
+func parseHostLines(text string, out *Policy) error {
+	return forEachEntry(text, func(line string) error {
+		line = strings.ToLower(line)
+		if ip := net.ParseIP(line); ip != nil {
+			out.ExactIPs = append(out.ExactIPs, ip.To16())
+			return nil
+		}
+		if strings.HasPrefix(line, "*.") {
+			suffix := strings.TrimPrefix(line, "*.")
+			suffix = strings.TrimSuffix(suffix, ".")
+			if suffix == "" || strings.Contains(suffix, "*") {
+				return fmt.Errorf("invalid deny host wildcard %q", line)
+			}
+			out.WildcardSuffixes = append(out.WildcardSuffixes, suffix)
+			return nil
+		}
+		if strings.Contains(line, "*") {
+			return fmt.Errorf("invalid deny host %q: only *.suffix wildcards are supported", line)
+		}
+		host := strings.TrimSuffix(line, ".")
+		if host == "" {
+			return fmt.Errorf("invalid empty deny host")
+		}
+		out.ExactHosts[host] = struct{}{}
+		return nil
+	})
+}
+
+func forEachEntry(text string, fn func(line string) error) error {
+	scanner := bufio.NewScanner(strings.NewReader(text))
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if i := strings.Index(line, "#"); i >= 0 {
+			line = strings.TrimSpace(line[:i])
+			if line == "" {
+				continue
+			}
+		}
+		if err := fn(line); err != nil {
+			return fmt.Errorf("line %d: %w", lineNo, err)
+		}
+	}
+	return scanner.Err()
+}

--- a/pkg/utils/httpguard/deny_source.go
+++ b/pkg/utils/httpguard/deny_source.go
@@ -72,7 +72,8 @@ func Current() Policy {
 
 // LoadConfigMap reads name from namespace and installs the denylist fragment.
 // Fail-closed: missing or invalid ConfigMaps return an error.
-func LoadConfigMap(ctx context.Context, c client.Client, name, namespace string) error {
+// c may be a cache Client or an API Reader (needed before mgr.Start).
+func LoadConfigMap(ctx context.Context, c client.Reader, name, namespace string) error {
 	if name == "" {
 		SetDenyFragment(Policy{ExactHosts: map[string]struct{}{}})
 		return nil

--- a/pkg/utils/httpguard/deny_source.go
+++ b/pkg/utils/httpguard/deny_source.go
@@ -140,7 +140,7 @@ type denyEventHandler struct {
 
 var _ cache.ResourceEventHandler = &denyEventHandler{}
 
-func (h *denyEventHandler) OnAdd(obj interface{}, _ bool)  { h.maybe(obj) }
+func (h *denyEventHandler) OnAdd(obj interface{})           { h.maybe(obj) }
 func (h *denyEventHandler) OnUpdate(_, newObj interface{}) { h.maybe(newObj) }
 func (h *denyEventHandler) OnDelete(obj interface{})       { h.maybe(obj) }
 

--- a/pkg/utils/httpguard/deny_source.go
+++ b/pkg/utils/httpguard/deny_source.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package httpguard
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+// PolicyEnhancer optionally mutates base policy (for example enabling
+// BlockPrivate from a feature gate) before denylist merge.
+type PolicyEnhancer func(Policy) Policy
+
+var (
+	denyFragment atomic.Value // stores Policy
+	enhancer     atomic.Value // stores PolicyEnhancer
+)
+
+func init() {
+	denyFragment.Store(Policy{ExactHosts: map[string]struct{}{}})
+	enhancer.Store(PolicyEnhancer(func(p Policy) Policy { return p }))
+}
+
+// SetEnhancer registers a hook applied on every Current() call.
+func SetEnhancer(fn PolicyEnhancer) {
+	if fn == nil {
+		fn = func(p Policy) Policy { return p }
+	}
+	enhancer.Store(fn)
+}
+
+// SetDenyFragment atomically replaces the denylist overlay.
+func SetDenyFragment(fragment Policy) {
+	if fragment.ExactHosts == nil {
+		fragment.ExactHosts = map[string]struct{}{}
+	}
+	denyFragment.Store(fragment)
+}
+
+// Current returns DefaultPolicy, then enhancer, then denylist merge.
+func Current() Policy {
+	base := DefaultPolicy()
+	if fn, ok := enhancer.Load().(PolicyEnhancer); ok && fn != nil {
+		base = fn(base)
+	}
+	fragment, _ := denyFragment.Load().(Policy)
+	return base.MergeDeny(fragment)
+}
+
+// LoadConfigMap reads name from namespace and installs the denylist fragment.
+// Fail-closed: missing or invalid ConfigMaps return an error.
+func LoadConfigMap(ctx context.Context, c client.Client, name, namespace string) error {
+	if name == "" {
+		SetDenyFragment(Policy{ExactHosts: map[string]struct{}{}})
+		return nil
+	}
+	cm := &corev1.ConfigMap{}
+	if err := c.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, cm); err != nil {
+		return fmt.Errorf("get workflow HTTP deny ConfigMap %s/%s: %w", namespace, name, err)
+	}
+	fragment, err := ParseConfigMap(cm)
+	if err != nil {
+		return fmt.Errorf("parse workflow HTTP deny ConfigMap %s/%s: %w", namespace, name, err)
+	}
+	SetDenyFragment(fragment)
+	return nil
+}
+
+// SetupWatcher registers a cache-backed ConfigMap watch in the controller
+// namespace. After startup, parse failures keep the last good policy and log.
+func SetupWatcher(mgr manager.Manager, name, namespace string) error {
+	if name == "" {
+		return nil
+	}
+	return mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
+		return watchAndReload(ctx, mgr.GetClient(), mgr, name, namespace)
+	}))
+}
+
+func watchAndReload(ctx context.Context, cli client.Client, mgr manager.Manager, name, namespace string) error {
+	informer, err := mgr.GetCache().GetInformer(ctx, &corev1.ConfigMap{})
+	if err != nil {
+		return fmt.Errorf("get ConfigMap informer for HTTP deny watch: %w", err)
+	}
+	reload := func() {
+		cm := &corev1.ConfigMap{}
+		if err := cli.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, cm); err != nil {
+			if apierrors.IsNotFound(err) {
+				klog.ErrorS(err, "workflow HTTP deny ConfigMap deleted; keeping last good policy", "name", name, "namespace", namespace)
+				return
+			}
+			klog.ErrorS(err, "failed to reload workflow HTTP deny ConfigMap", "name", name, "namespace", namespace)
+			return
+		}
+		fragment, err := ParseConfigMap(cm)
+		if err != nil {
+			klog.ErrorS(err, "invalid workflow HTTP deny ConfigMap update; keeping last good policy", "name", name, "namespace", namespace)
+			return
+		}
+		SetDenyFragment(fragment)
+		klog.InfoS("reloaded workflow HTTP deny ConfigMap", "name", name, "namespace", namespace)
+	}
+
+	handler := &denyEventHandler{reload: reload, name: name, namespace: namespace}
+	_, err = informer.AddEventHandler(handler)
+	if err != nil {
+		return err
+	}
+	<-ctx.Done()
+	return nil
+}
+
+type denyEventHandler struct {
+	reload          func()
+	name, namespace string
+}
+
+var _ cache.ResourceEventHandler = &denyEventHandler{}
+
+func (h *denyEventHandler) OnAdd(obj interface{}, _ bool)  { h.maybe(obj) }
+func (h *denyEventHandler) OnUpdate(_, newObj interface{}) { h.maybe(newObj) }
+func (h *denyEventHandler) OnDelete(obj interface{})       { h.maybe(obj) }
+
+func (h *denyEventHandler) maybe(obj interface{}) {
+	cm, ok := obj.(*corev1.ConfigMap)
+	if !ok {
+		if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+			cm, ok = tombstone.Obj.(*corev1.ConfigMap)
+			if !ok {
+				return
+			}
+		} else {
+			return
+		}
+	}
+	if cm.Name != h.name || cm.Namespace != h.namespace {
+		return
+	}
+	h.reload()
+}

--- a/pkg/utils/httpguard/deny_source_test.go
+++ b/pkg/utils/httpguard/deny_source_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package httpguard
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestLoadConfigMap(t *testing.T) {
+	scheme := testScheme(t)
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "workflow-http-deny", Namespace: "vela-system"},
+		Data: map[string]string{
+			ConfigMapKeyDenyCIDRs: "10.0.0.0/8",
+			ConfigMapKeyDenyHosts: "metadata.google.internal",
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
+	require.NoError(t, LoadConfigMap(context.Background(), cli, "workflow-http-deny", "vela-system"))
+	p := Current()
+	require.True(t, p.Blocked(net.ParseIP("10.1.1.1")))
+	require.Error(t, p.BlockedHost("metadata.google.internal"))
+}
+
+func TestLoadConfigMap_invalid(t *testing.T) {
+	scheme := testScheme(t)
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "bad", Namespace: "vela-system"},
+		Data: map[string]string{
+			ConfigMapKeyDenyCIDRs: "invalid-cidr",
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
+	err := LoadConfigMap(context.Background(), cli, "bad", "vela-system")
+	require.Error(t, err)
+}
+
+func testScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(s))
+	return s
+}

--- a/pkg/utils/httpguard/policy.go
+++ b/pkg/utils/httpguard/policy.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package httpguard
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+// Policy controls which destination hosts and IPs outbound HTTP clients may
+// connect to. Host checks run on the URL before dial; IP checks run at dial
+// time on the resolved address.
+type Policy struct {
+	// BlockLinkLocal denies link-local unicast (169.254.0.0/16, fe80::/10).
+	BlockLinkLocal bool
+	// BlockMetadata denies curated cloud metadata endpoints that fall outside
+	// link-local (for example AWS IPv6 IMDS and Alibaba metadata).
+	BlockMetadata bool
+	// BlockPrivate denies RFC-1918 and RFC-4193 ULA ranges. Off by default
+	// because workflow HTTP steps legitimately call in-cluster ClusterIP services.
+	BlockPrivate bool
+	// BlockLoopback denies 127.0.0.0/8 and ::1. Off by default.
+	BlockLoopback bool
+	// DenyCIDRs blocks any destination IP contained in these networks.
+	DenyCIDRs []*net.IPNet
+	ExactIPs  []net.IP
+	// ExactHosts are lower-case hostnames that must be rejected.
+	ExactHosts map[string]struct{}
+	// WildcardSuffixes are lower-case DNS suffixes without the leading "*."
+	// (for example "corp.internal" from "*.corp.internal").
+	WildcardSuffixes []string
+}
+
+// DefaultPolicy is the secure-by-default posture for controller outbound HTTP:
+// block link-local and known cloud metadata, allow private and loopback.
+func DefaultPolicy() Policy {
+	return Policy{
+		BlockLinkLocal: true,
+		BlockMetadata:  true,
+		ExactHosts:     map[string]struct{}{},
+	}
+}
+
+var metadataIPs = func() []net.IP {
+	raw := []string{
+		"fd00:ec2::254",   // AWS IPv6 IMDS
+		"100.100.100.200", // Alibaba Cloud metadata
+	}
+	out := make([]net.IP, 0, len(raw))
+	for _, s := range raw {
+		if ip := net.ParseIP(s); ip != nil {
+			out = append(out, ip)
+		}
+	}
+	return out
+}()
+
+// MergeDeny overlays denylist CIDRs/hosts from other onto p.
+func (p Policy) MergeDeny(other Policy) Policy {
+	if len(other.DenyCIDRs) > 0 {
+		p.DenyCIDRs = append(append([]*net.IPNet{}, p.DenyCIDRs...), other.DenyCIDRs...)
+	}
+	if len(other.ExactIPs) > 0 {
+		p.ExactIPs = append(append([]net.IP{}, p.ExactIPs...), other.ExactIPs...)
+	}
+	if p.ExactHosts == nil {
+		p.ExactHosts = map[string]struct{}{}
+	}
+	for host := range other.ExactHosts {
+		p.ExactHosts[host] = struct{}{}
+	}
+	if len(other.WildcardSuffixes) > 0 {
+		p.WildcardSuffixes = append(append([]string{}, p.WildcardSuffixes...), other.WildcardSuffixes...)
+	}
+	return p
+}
+
+// Blocked reports whether ip must be rejected under policy.
+func (p Policy) Blocked(ip net.IP) bool {
+	if ip == nil {
+		return false
+	}
+	ip = ip.To16()
+	if ip == nil {
+		return false
+	}
+	if p.BlockLoopback && ip.IsLoopback() {
+		return true
+	}
+	if p.BlockPrivate && ip.IsPrivate() {
+		return true
+	}
+	if p.BlockLinkLocal && ip.IsLinkLocalUnicast() {
+		return true
+	}
+	if p.BlockMetadata {
+		for _, metadata := range metadataIPs {
+			if ip.Equal(metadata) {
+				return true
+			}
+		}
+	}
+	for _, exact := range p.ExactIPs {
+		if ip.Equal(exact) {
+			return true
+		}
+	}
+	for _, cidr := range p.DenyCIDRs {
+		if cidr != nil && cidr.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// BlockedHost reports whether hostname must be rejected under the denylist.
+// Host may include a port; IP literals are checked against ExactIPs/DenyCIDRs.
+func (p Policy) BlockedHost(host string) error {
+	host = normalizeHost(host)
+	if host == "" {
+		return nil
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		if p.Blocked(ip) {
+			return fmt.Errorf("blocked SSRF target: %s", ip)
+		}
+		return nil
+	}
+	if _, ok := p.ExactHosts[host]; ok {
+		return fmt.Errorf("blocked SSRF host: %s", host)
+	}
+	for _, suffix := range p.WildcardSuffixes {
+		if host == suffix {
+			continue
+		}
+		if strings.HasSuffix(host, "."+suffix) {
+			return fmt.Errorf("blocked SSRF host: %s", host)
+		}
+	}
+	return nil
+}
+
+// BlockedAddress parses host:port from a dial address and reports whether it
+// is blocked. Non-IP hosts are allowed through; host denylist must be checked
+// separately via BlockedHost before dial.
+func (p Policy) BlockedAddress(address string) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return err
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return nil
+	}
+	if p.Blocked(ip) {
+		return fmt.Errorf("blocked SSRF target: %s", ip)
+	}
+	return nil
+}
+
+func normalizeHost(host string) string {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return ""
+	}
+	// Strip brackets from IPv6 literals like [::1]:443 after SplitHostPort, or
+	// raw hostname:port when callers pass URL.Host.
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	host = strings.TrimPrefix(host, "[")
+	host = strings.TrimSuffix(host, "]")
+	return strings.ToLower(host)
+}

--- a/pkg/utils/httpguard/policy_test.go
+++ b/pkg/utils/httpguard/policy_test.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package httpguard
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestDefaultPolicy_blocksMetadataAndLinkLocal(t *testing.T) {
+	policy := DefaultPolicy()
+
+	blocked := []string{
+		"169.254.169.254",
+		"169.254.0.1",
+		"fd00:ec2::254",
+		"100.100.100.200",
+	}
+	for _, raw := range blocked {
+		ip := net.ParseIP(raw)
+		require.NotNil(t, ip, raw)
+		assert.True(t, policy.Blocked(ip), "expected %s blocked", raw)
+	}
+
+	allowed := []string{
+		"127.0.0.1",
+		"10.0.0.1",
+		"192.168.1.1",
+		"8.8.8.8",
+	}
+	for _, raw := range allowed {
+		ip := net.ParseIP(raw)
+		require.NotNil(t, ip, raw)
+		assert.False(t, policy.Blocked(ip), "expected %s allowed", raw)
+	}
+}
+
+func TestParseDenyList(t *testing.T) {
+	policy, err := ParseDenyList(`
+# cidrs
+10.0.0.0/8
+169.254.169.254
+`, `
+metadata.google.internal
+*.corp.internal
+8.8.4.4
+`)
+	require.NoError(t, err)
+	assert.True(t, policy.Blocked(net.ParseIP("10.1.2.3")))
+	assert.True(t, policy.Blocked(net.ParseIP("169.254.169.254")))
+	assert.True(t, policy.Blocked(net.ParseIP("8.8.4.4")))
+	assert.False(t, policy.Blocked(net.ParseIP("8.8.8.8")))
+
+	require.NoError(t, policy.BlockedHost("public.example.com"))
+	require.Error(t, policy.BlockedHost("metadata.google.internal"))
+	require.Error(t, policy.BlockedHost("a.corp.internal"))
+	require.Error(t, policy.BlockedHost("a.b.corp.internal"))
+	require.NoError(t, policy.BlockedHost("corp.internal"))
+}
+
+func TestParseDenyList_invalid(t *testing.T) {
+	_, err := ParseDenyList("not-a-cidr", "")
+	require.Error(t, err)
+	_, err = ParseDenyList("", "foo.*.bar")
+	require.Error(t, err)
+}
+
+func TestParseConfigMap(t *testing.T) {
+	cm := &corev1.ConfigMap{Data: map[string]string{
+		ConfigMapKeyDenyCIDRs: "192.168.0.0/16",
+		ConfigMapKeyDenyHosts: "evil.example",
+	}}
+	policy, err := ParseConfigMap(cm)
+	require.NoError(t, err)
+	assert.True(t, policy.Blocked(net.ParseIP("192.168.1.1")))
+	require.Error(t, policy.BlockedHost("evil.example"))
+}
+
+func TestCurrent_mergesDenyAndEnhancer(t *testing.T) {
+	t.Cleanup(func() {
+		SetDenyFragment(Policy{ExactHosts: map[string]struct{}{}})
+		SetEnhancer(nil)
+	})
+	SetEnhancer(func(p Policy) Policy {
+		p.BlockPrivate = true
+		return p
+	})
+	fragment, err := ParseDenyList("", "blocked.example")
+	require.NoError(t, err)
+	SetDenyFragment(fragment)
+
+	cur := Current()
+	assert.True(t, cur.BlockPrivate)
+	assert.True(t, cur.BlockLinkLocal)
+	require.Error(t, cur.BlockedHost("blocked.example"))
+	assert.True(t, cur.Blocked(net.ParseIP("10.0.0.1")))
+}
+
+func TestSecureTransport_blocksLinkLocalDial(t *testing.T) {
+	client := &http.Client{
+		Transport: SecureTransport(http.DefaultTransport.(*http.Transport).Clone(), DefaultPolicy()),
+	}
+	_, err := client.Get("http://169.254.169.254/latest/meta-data/")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "blocked SSRF target")
+}
+
+func TestSecureTransport_allowsLoopback(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer ts.Close()
+
+	client := &http.Client{
+		Transport: SecureTransport(http.DefaultTransport.(*http.Transport).Clone(), DefaultPolicy()),
+	}
+	resp, err := client.Get(ts.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestSecureTransport_redirectRevalidated(t *testing.T) {
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://169.254.169.254/latest/meta-data/", http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	client := &http.Client{
+		Transport: SecureTransport(http.DefaultTransport.(*http.Transport).Clone(), DefaultPolicy()),
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return nil
+		},
+	}
+	_, err := client.Get(redirector.URL)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "blocked SSRF target")
+}
+
+func TestSecureTransport_blocksDenyCIDR(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	fragment, err := ParseDenyList("127.0.0.0/8", "")
+	require.NoError(t, err)
+	policy := DefaultPolicy().MergeDeny(fragment)
+	client := &http.Client{
+		Transport: SecureTransport(http.DefaultTransport.(*http.Transport).Clone(), policy),
+	}
+	_, err = client.Get(ts.URL)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "blocked SSRF target")
+}

--- a/pkg/utils/httpguard/transport.go
+++ b/pkg/utils/httpguard/transport.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2026 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package httpguard
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"syscall"
+)
+
+// SecureTransport wires SSRF address validation into transport dialing.
+func SecureTransport(base *http.Transport, policy Policy) *http.Transport {
+	if base == nil {
+		base = http.DefaultTransport.(*http.Transport).Clone()
+	}
+	dialer := &net.Dialer{}
+	dialer.Control = func(_, address string, _ syscall.RawConn) error {
+		return policy.BlockedAddress(address)
+	}
+	base.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		if err := policy.BlockedAddress(address); err != nil {
+			return nil, err
+		}
+		return dialer.DialContext(ctx, network, address)
+	}
+	return base
+}


### PR DESCRIPTION
### Description of your changes

Backport of ConfigMap-driven workflow HTTP denylist / SSRF hardening to `release-0.6` for KubeVela `release-1.9`.

Changes (adapted to release-0.6 layout):

- `pkg/utils/httpguard` policy, ConfigMap parse/load/watch, transport helper
- HTTP provider checks in `pkg/providers/http/do.go` (release-0.6 path)
- Feature gates in `pkg/features/controller_features.go`
- Helm values/flags for deny ConfigMap and HTTP feature gates
- Startup fix: initial deny ConfigMap load via `mgr.GetAPIReader()` (cache not ready before `mgr.Start`)
- Release-0.6 compatibility commit for informer API and missing transport helper

Pairs with KubeVela `backport/http-denylist-release-1.9` (pending maintainer fork).

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

- Unit tests: `pkg/utils/httpguard/...`, selected `pkg/providers/http/...` tests
- k3d pair test `ssrf-pair-19` (`local/vela-workflow:bp06` + `local/vela-core:bp19`): controllers Ready, deny ConfigMap reload, smoke `WorkflowRun` blocked `blocked.example.com`

### Special notes for your reviewer

Target merge order relative to KubeVela:

1. Merge this workflow PR to `release-0.6` and cut/publish a workflow pseudo-version for KV 1.9
2. Then merge KubeVela `backport/http-denylist-release-1.9` with updated `go.mod` workflow pin

Independent of the mainline workflow PR (`fix/ssrf-http-guard` → `main`).