### PR TITLE
Fix: report step failure when the CUE template fails to compile

### DIFF
--- a/e2e/http_secret_test.go
+++ b/e2e/http_secret_test.go
@@ -74,6 +74,9 @@ var _ = Describe("Test the request step resolving headers from a Kubernetes Secr
 })
 
 func deployMockServer(ctx context.Context) {
+	// The body must be valid JSON: the request step definition ends with
+	// response: json.Unmarshal(req.$returns.body), so a non-JSON body makes the step
+	// template fail to evaluate with `json: invalid JSON`.
 	nginxConfig := `
 server {
     listen 80;
@@ -81,7 +84,8 @@ server {
         if ($http_authorization != "Bearer sk-supersecret-12345") {
             return 401;
         }
-        return 200 "OK";
+        default_type application/json;
+        return 200 '{"status":"ok"}';
     }
 }
 `

--- a/pkg/tasks/custom/task.go
+++ b/pkg/tasks/custom/task.go
@@ -243,7 +243,16 @@ func (t *TaskLoader) makeTaskGenerator(templ string) (types.TaskGenerator, error
 				}
 			}
 
-			if exec.stepStatus.Phase == v1alpha1.WorkflowStepPhaseSucceeded && taskv.Err() != nil {
+			// Check wfStatus (this reconcile), not stepStatus (the previous one).
+			// wfStatus starts at the neutral Succeeded default and is set to
+			// Running/Suspending/Failed by Wait()/Suspend()/err() if an action claimed a
+			// specific outcome while CompileString ran. Still holding the default means
+			// nothing claimed one, so a template error is ours to report.
+			//
+			// Reading stepStatus instead meant that once a reconcile persisted Failed, every
+			// later reconcile skipped this check and returned the untouched Succeeded
+			// default -- reporting success for a step whose actions never ran.
+			if exec.wfStatus.Phase == v1alpha1.WorkflowStepPhaseSucceeded && taskv.Err() != nil {
 				tracer.Error(taskv.Err(), "do steps")
 				exec.err(wfCtx, true, taskv.Err(), types.StatusReasonExecute)
 				return exec.status(), exec.operation(), nil

--- a/pkg/tasks/custom/task_test.go
+++ b/pkg/tasks/custom/task_test.go
@@ -689,6 +689,158 @@ name: context.name
 	}
 }
 
+// TestTemplateErrorPersistsAcrossReconciles guards against a step whose CUE template
+// fails to compile reporting Succeeded on the second and later reconciles.
+//
+// The bug: the guard in makeTaskGenerator read exec.stepStatus (the PREVIOUS
+// reconcile's phase) instead of exec.wfStatus (this reconcile's). Once pass 1
+// persisted Failed, pass 2 saw Failed, skipped the taskv.Err() check entirely, and
+// returned the untouched optimistic Succeeded default.
+//
+// Two things are essential to reaching the bug, and omitting either hides it:
+//
+//  1. Feed the returned status back in as options.StepStatus before the second run.
+//     That is what pkg/executor/workflow.go:730 does. Without it, stepStatus stays at
+//     its default and the guard is always true (see the "failed-after-retries" case in
+//     TestTaskLoader, which loops but never feeds status back).
+//  2. Call the generator again for the second pass. The executor struct -- and the
+//     optimistic Succeeded seed on wfStatus -- is created per generator call, not per
+//     Run call. A reconcile regenerates runners
+//     (controllers/workflowrun_controller.go:134), so reusing one runner would carry
+//     pass 1's Failed wfStatus into pass 2 and mask the defect.
+func TestTemplateErrorPersistsAcrossReconciles(t *testing.T) {
+	r := require.New(t)
+
+	// Reset the in-memory failure counter. checkErrorTimes (action.go:145-152) keys it on
+	// exec.wfStatus.ID, which is empty when TaskGeneratorOptions carries no ID -- so it is
+	// shared with every other test using the app-v1/default context. At
+	// MaxWorkflowStepErrorRetryTimes (10) the reason flips to StatusReasonFailedAfterRetries
+	// and the assertions below would fail for an unrelated reason.
+	wfContext.CleanupMemoryStore("app-v1", "default")
+	wfCtx := newWorkflowContextForTest(t)
+
+	compiler := cuex.NewCompilerWithInternalPackages(
+		pkgruntime.Must(cuexruntime.NewInternalPackage("test", "", map[string]cuexruntime.ProviderFn{
+			// Returns a value carrying an unresolved reference, so taskv.Err() != nil.
+			"templateError": cuexruntime.NativeProviderFn(func(ctx context.Context, v cue.Value) (cue.Value, error) {
+				return v.Context().CompileString("output: xxx"), nil
+			}),
+		})),
+	)
+
+	pCtx := process.NewContext(process.ContextData{
+		Name:      "app",
+		Namespace: "default",
+	})
+	tasksLoader := NewTaskLoader(mockLoadTemplate, 0, pCtx, compiler)
+
+	step := oamv1alpha1.WorkflowStep{
+		WorkflowStepBase: oamv1alpha1.WorkflowStepBase{
+			Name: "template",
+			Type: "templateError",
+		},
+	}
+
+	gen, err := tasksLoader.GetTaskGenerator(context.Background(), step.Type)
+	r.NoError(err)
+	run, err := gen(step, &types.TaskGeneratorOptions{})
+	r.NoError(err)
+
+	// Pass 1: no persisted status yet.
+	firstStatus, _, err := run.Run(wfCtx, &types.TaskRunOptions{})
+	r.NoError(err)
+	r.Equal(v1alpha1.WorkflowStepPhaseFailed, firstStatus.Phase, "first reconcile must fail")
+	r.Equal(types.StatusReasonExecute, firstStatus.Reason)
+	r.NotEmpty(firstStatus.Message, "first reconcile must report the compile error")
+
+	// Pass 2: a fresh runner, as a reconcile produces, plus pass 1's status fed back.
+	secondRun, err := gen(step, &types.TaskGeneratorOptions{})
+	r.NoError(err)
+	secondStatus, _, err := secondRun.Run(wfCtx, &types.TaskRunOptions{
+		StepStatus: map[string]v1alpha1.StepStatus{
+			step.Name: firstStatus,
+		},
+	})
+	r.NoError(err)
+	r.Equal(v1alpha1.WorkflowStepPhaseFailed, secondStatus.Phase,
+		"template is still broken, so the second reconcile must still fail")
+	r.Equal(types.StatusReasonExecute, secondStatus.Reason)
+	r.NotEmpty(secondStatus.Message,
+		"second reconcile must still report the compile error, not an empty-message success")
+}
+
+// TestInFlightStatusSurvivesSecondReconcile asserts that a step which reports itself as
+// waiting or suspended keeps that phase on a later reconcile, with its previous status
+// fed back in. A step mid-flight has a legitimately incomplete CUE value, so the
+// template-error check at task.go must stay skipped for it.
+func TestInFlightStatusSurvivesSecondReconcile(t *testing.T) {
+	r := require.New(t)
+
+	compiler := cuex.NewCompilerWithInternalPackages(
+		pkgruntime.Must(cuexruntime.NewInternalPackage("test", "", map[string]cuexruntime.ProviderFn{
+			"wait": providertypes.LegacyGenericProviderFn[any, any](func(ctx context.Context, val *providertypes.LegacyParams[any]) (*any, error) {
+				val.RuntimeParams.Action.Wait("I am waiting")
+				return nil, nil
+			}),
+			"suspend": providertypes.LegacyGenericProviderFn[any, any](func(ctx context.Context, val *providertypes.LegacyParams[any]) (*any, error) {
+				val.RuntimeParams.Action.Suspend("I am suspended")
+				return nil, nil
+			}),
+		})),
+	)
+
+	pCtx := process.NewContext(process.ContextData{
+		Name:      "app",
+		Namespace: "default",
+	})
+	tasksLoader := NewTaskLoader(mockLoadTemplate, 0, pCtx, compiler)
+
+	testCases := []struct {
+		stepType      string
+		expectedPhase v1alpha1.WorkflowStepPhase
+	}{
+		{stepType: "wait", expectedPhase: v1alpha1.WorkflowStepPhaseRunning},
+		{stepType: "suspend", expectedPhase: v1alpha1.WorkflowStepPhaseSuspending},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.stepType, func(t *testing.T) {
+			// Isolate each subtest from the shared in-memory failure counter. See the
+			// comment in TestTemplateErrorPersistsAcrossReconciles.
+			wfContext.CleanupMemoryStore("app-v1", "default")
+			wfCtx := newWorkflowContextForTest(t)
+
+			step := oamv1alpha1.WorkflowStep{
+				WorkflowStepBase: oamv1alpha1.WorkflowStepBase{
+					Name: tc.stepType,
+					Type: tc.stepType,
+				},
+			}
+
+			gen, err := tasksLoader.GetTaskGenerator(context.Background(), step.Type)
+			r.NoError(err)
+
+			run, err := gen(step, &types.TaskGeneratorOptions{})
+			r.NoError(err)
+			firstStatus, _, err := run.Run(wfCtx, &types.TaskRunOptions{})
+			r.NoError(err)
+			r.Equal(tc.expectedPhase, firstStatus.Phase)
+
+			// Fresh runner for the second pass, as a reconcile produces.
+			secondRun, err := gen(step, &types.TaskGeneratorOptions{})
+			r.NoError(err)
+			secondStatus, _, err := secondRun.Run(wfCtx, &types.TaskRunOptions{
+				StepStatus: map[string]v1alpha1.StepStatus{
+					step.Name: firstStatus,
+				},
+			})
+			r.NoError(err)
+			r.Equal(tc.expectedPhase, secondStatus.Phase,
+				"an in-flight step must not be flipped to Failed by the template-error check")
+		})
+	}
+}
+
 var (
 	testCaseYaml = `apiVersion: v1
 data:


### PR DESCRIPTION
### Description of your changes

The check that surfaces a step template error read exec.stepStatus — the previous reconcile's phase — where exec.wfStatus, this reconcile's, was intended. wfStatus is re-seeded to the neutral Succeeded default in the task generator on every reconcile; stepStatus is loaded from the persisted status.

So the first reconcile caught the error and recorded Failed, and every later reconcile read that Failed, skipped the check, and returned the untouched Succeeded default — reporting success for a step whose actions never ran. Recording the failure disabled the check that found it. For a standalone WorkflowRun the false succeeded was permanent, since a finished run is skipped on reconcile.

Reading wfStatus leaves the in-flight paths alone: Wait() and Suspend() set it to Running and Suspending while CompileString evaluates the template, so a mid-flight step still bypasses the check.

Fixes kubevela/kubevela#7275

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

New test TestTemplateErrorPersistsAcrossReconciles in pkg/tasks/custom/task_test.go. It runs a step whose template fails to evaluate, then runs it a second time with the first pass's status fed back in as options.StepStatus, and asserts the second pass is still Failed with a non-empty message. On master the second pass returns succeeded with an empty message; with this change it stays Failed.

Also added TestInFlightStatusSurvivesSecondReconcile, which asserts a Wait() step stays Running and a Suspend() step stays Suspending across two passes.

go test ./pkg/tasks/... passes. Originally found in a live cluster: a WorkflowStepDefinition with an unused CUE import (rejected by CUE 0.14.x) whose only action deleted a pod. The run reported succeeded while the pod was untouched.


### Special notes for your reviewer

Two things are needed to reach this bug, which is why no existing test caught it. The status has to be fed back in as options.StepStatus, and the runner has to be regenerated for the second pass — the executor struct, and therefore the optimistic seed on wfStatus, is created per generator call rather than per Run call. Reusing one runner carries pass 1's Failed into pass 2 and hides the defect. Real reconciles regenerate runners (controllers/workflowrun_controller.go:134). The existing failed-after-retries case loops but omits the first ingredient.

Why this is narrow. On the first reconcile stepStatus and wfStatus both hold the same default, so behaviour there is unchanged. The fix only affects reconciles after the first, making them behave as the first already does — so it cannot introduce a failure mode that does not already occur.

One behaviour change worth calling out. A step with a persistently broken template now consumes errorRetryTimes and fails the workflow, instead of reporting success on the retry. A run that completes in seconds today will retry and then fail. That is the intent, but it will be visible to anyone tracking run duration or alerting on workflow failures.

On the phase condition itself. I read it as protecting steps that are legitimately mid-flight, but that is inference. Deleting the condition outright leaves the wait and suspend tests passing, because those steps leave a clean taskv and never reach the taskv.Err() != nil half. I kept it since it is clearly deliberate and harmless, but if you know the original intent I would rather match it.

Origin. Introduced in 7d94489 (#162, "Chore: refactor the cue engine with cuex"), which replaced an explicit doSteps() call and its unconditional error handling with the post-hoc taskv.Err() inspection.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes steps incorrectly reported as succeeded after a CUE template compile error. We now read `wfStatus` (this reconcile) instead of `stepStatus` (previous reconcile) so compile failures are surfaced every time.

- **Bug Fixes**
  - Gate template-error reporting on `exec.wfStatus` rather than `exec.stepStatus`.
  - Preserve in-flight states: `Wait()` stays Running and `Suspend()` stays Suspending.
  - Added tests: `TestTemplateErrorPersistsAcrossReconciles`, `TestInFlightStatusSurvivesSecondReconcile`.
  - e2e mock server now returns valid JSON with `application/json` to avoid `json.Unmarshal` template errors.

- **Migration**
  - Steps with persistently broken templates now consume `errorRetryTimes` and fail the workflow, instead of falsely succeeding.

<sup>Written for commit 105d3d309f11a93e3f2bbc88ab418e3e0f59ae12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kubevela/workflow/pull/244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

