### PR TITLE
Chore: Add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # This file is a github code protect rule follow the codeowners https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#example-of-a-codeowners-file
 
-*  @FogDong @wonderflow @leejanee @Somefive @anoop2811 @briankane @jguionnet
+*  @FogDong @wonderflow @leejanee @Somefive @anoop2811 @briankane @jguionnet @roguepikachu


### PR DESCRIPTION
## Summary
- Add @roguepikachu to CODEOWNERS
- Related: https://github.com/kubevela/community/issues/271
- Related: https://github.com/kubevela/community/pull/272

## Test plan
- [ ] Confirm @roguepikachu is listed on owned paths
- [ ] Maintainer/reviewer approval


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add @roguepikachu to the global `CODEOWNERS` rule so they are a code owner for all files. This ensures PRs auto-request their review and branch protections include them.

<sup>Written for commit c017b2a7771545048072e80548f0771043ff6cac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kubevela/workflow/pull/248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

