### PR TITLE
Chore: Add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # This file is a github code protect rule follow the codeowners https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#example-of-a-codeowners-file
 
-*  @FogDong @wonderflow @leejanee @Somefive @anoop2811 @briankane @jguionnet @roguepikachu
+*  @FogDong @wonderflow @leejanee @Somefive @anoop2811 @briankane @jguionnet @roguepikachu @jerrinfrancis


### PR DESCRIPTION
## Summary
- Add @jerrinfrancis to CODEOWNERS
- Related: https://github.com/kubevela/community/issues/274
- Related: https://github.com/kubevela/community/pull/275

## Test plan
- [ ] Confirm @jerrinfrancis is listed on owned paths
- [ ] Maintainer/reviewer approval

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@jerrinfrancis` to the global `*` entry in `CODEOWNERS` so GitHub auto-requests their review on all PRs. Previously their review was not requested; now all file changes include them as a code owner.

- Scope: applies to all files via `*`; no code, CI, or runtime changes.
- If branch protection requires code owner reviews, GitHub will request `@jerrinfrancis`; approval thresholds are unchanged.

<sup>Written for commit 4b6ea27b69c6d795a137e759c1384667ed40b87d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kubevela/workflow/pull/252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

